### PR TITLE
Tweaked mouse event handlers in HeliosVisual.cs

### DIFF
--- a/Helios/HeliosVisual.cs
+++ b/Helios/HeliosVisual.cs
@@ -556,19 +556,28 @@ namespace GadrocsWorkshop.Helios
         /// Called when a mouse button is pressed on this control.
         /// </summary>
         /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
-        public abstract void MouseDown(Point location);
+        public virtual void MouseDown(Point location)
+        {
+            // no code in base
+        }
 
         /// <summary>
         /// Called when the mouse is dragged after being pressed on this control.
         /// </summary>
         /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
-        public abstract void MouseDrag(Point location);
+        public virtual void MouseDrag(Point location)
+        {
+            // no code in base    
+        }
 
         /// <summary>
         /// Called when the mouse button is released after being pressed on this control.
         /// </summary>
         /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
-        public abstract void MouseUp(Point location);
+        public virtual void MouseUp(Point location)
+        {
+            // no code in base
+        }
 
         private void Children_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {

--- a/Helios/HeliosVisual.cs
+++ b/Helios/HeliosVisual.cs
@@ -553,10 +553,30 @@ namespace GadrocsWorkshop.Helios
         }
 
         /// <summary>
+        /// Called when a mouse wheel is rotated on this control.
+        /// </summary>
+        /// <param name="delta">Signed change in mouse wheel value.</param>
+        /// <param name="e">Original event arguments.</param>
+        public virtual void MouseWheelWithArgs(int delta, MouseWheelEventArgs e)
+        {
+            // no code in base
+        }
+
+        /// <summary>
         /// Called when a mouse button is pressed on this control.
         /// </summary>
         /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
         public virtual void MouseDown(Point location)
+        {
+            // no code in base
+        }
+
+        /// <summary>
+        /// Called when a mouse button is pressed on this control.
+        /// </summary>
+        /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
+        /// <param name="e">Original event arguments.</param>
+        public virtual void MouseDownWithArgs(Point location, MouseButtonEventArgs e)
         {
             // no code in base
         }
@@ -571,10 +591,30 @@ namespace GadrocsWorkshop.Helios
         }
 
         /// <summary>
+        /// Called when the mouse is dragged after being pressed on this control.
+        /// </summary>
+        /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
+        /// <param name="e">Original event arguments.</param>
+        public virtual void MouseDragWithArgs(Point location, MouseEventArgs e)
+        {
+            // no code in base
+        }
+
+        /// <summary>
         /// Called when the mouse button is released after being pressed on this control.
         /// </summary>
         /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
         public virtual void MouseUp(Point location)
+        {
+            // no code in base
+        }
+
+        /// <summary>
+        /// Called when the mouse button is released after being pressed on this control.
+        /// </summary>
+        /// <param name="location">Current location of the mouse relative to this controls upper left corner.</param>
+        /// <param name="e">Original event arguments.</param>
+        public virtual void MouseUpWithArgs(Point location, MouseButtonEventArgs e)
         {
             // no code in base
         }

--- a/Helios/Windows/Controls/HeliosVisualView.cs
+++ b/Helios/Windows/Controls/HeliosVisualView.cs
@@ -534,6 +534,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
             {
                 Point location = e.GetPosition(this);
                 Visual.MouseDrag(location);
+                Visual.MouseDragWithArgs(location, e);
                 e.Handled = true;
             }
         }
@@ -559,6 +560,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
                 }
                 Point location = e.GetPosition(this);
                 Visual.MouseUp(location);
+                Visual.MouseUpWithArgs(location, e);
                 e.MouseDevice.Capture(null);
                 ReleaseMouseCapture();
                 e.Handled = true;
@@ -644,6 +646,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
         {
             int delta = e.Delta;
             Visual.MouseWheel(delta);
+            Visual.MouseWheelWithArgs(delta, e);
             e.Handled = true;
         }
     }


### PR DESCRIPTION
This PR encompasses two small changes I've made to the mouse event handling in HeliosVisual.cs and HeliosVisualView.cs. The changes are as follows:

- **Within `GadrocsWorkshop.Helios.HeliosVisual`, the `MouseUp`, `MouseDown`, and `MouseDrag` methods are now declared as `public virtual void` instead of `public abstract void`.** This eliminates the need for controls extending `HeliosVisual` to override these methods even if they have no need to handle those events. No-op function definitions have been defined like what has already been done for the `MouseWheel` method. 
- **Alternate versions of the `MouseUp`, `MouseDown`, `MouseDrag` and `MouseWheel` handlers have been added that accept event arguments from `HeliosVisualView`.** This provides the ability to implement more advanced event handling (e.g. right vs left click, etc). The new handlers are called directly after their existing counterparts.

I've structured my changes to have very little (if any) impact on existing modules in the base install of Helios. There are, however, a few caveats that should be taken into account:

- The code makes no attempt to verify or handle situations in which both mouse handler types are overridden (e.g. both `MouseUp` and `MouseUpWithArgs` are defined). In this case, both will be called and odd things could happen.
- New methods have not been implemented for Touch events. Since they have different event argument types, yet still trigger the mouse event handlers in `HeliosVisual`, their implementation will take a little more thought. I'm considering reimplementing them to be a bit more independent of the mouse events, and to have support for multitouch. Any thoughts/ideas on decoupling those would be more than welcome!