### PR TITLE
added quoting in project files to allow building from paths with spaces.

### DIFF
--- a/Tools/GenerateSimulatorViewportTemplates/GenerateSimulatorViewportTemplates.csproj
+++ b/Tools/GenerateSimulatorViewportTemplates/GenerateSimulatorViewportTemplates.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <Import Project="..\..\Helios.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(TargetPath) $(ProjectDir)..\ToolsCommon\Data\Viewports\ViewportTemplates.json $(ProjectDir)..\..\Patching\Templates\Patching true
-$(TargetPath) $(ProjectDir)..\ToolsCommon\Data\Viewports\ExistingViewportTemplates.json $(ProjectDir)..\..\Helios\Templates\Base false</PostBuildEvent>
+    <PostBuildEvent>"$(TargetPath)" "$(ProjectDir)..\ToolsCommon\Data\Viewports\ViewportTemplates.json" "$(ProjectDir)..\..\Patching\Templates\Patching" true
+"$(TargetPath)" "$(ProjectDir)..\ToolsCommon\Data\Viewports\ExistingViewportTemplates.json" "$(ProjectDir)..\..\Helios\Templates\Base" false</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Tools/InitSubmodules/InitSubmodules.csproj
+++ b/Tools/InitSubmodules/InitSubmodules.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <Import Project="..\..\Helios.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if exist lib $(TargetPath)</PostBuildEvent>
+    <PostBuildEvent>if exist lib "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
As it currently stands building the `GenerateSimulatorViewportTemplates` and `InitSubmodules` projects fails when run from paths containing spaces due to missing quoting in their Post-Build event configurations. This PR adds proper quoting to allow these builds to succeed.