### PR TITLE
Falcon Interface - Added Target Clear Binding to Target Selection

### DIFF
--- a/HeliosFalcon/Controls/MapControl.cs
+++ b/HeliosFalcon/Controls/MapControl.cs
@@ -37,6 +37,7 @@ namespace GadrocsWorkshop.Helios.Controls
 		private HeliosValue _threatsVisible;
 		private HeliosValue _waypointsVisible;
 		private HeliosValue _overviewPanelVisible;
+		private HeliosValue _overviewClearTarget;
 		private HeliosValue _overviewRangeRingsVisible;
 
 		private Gauges.GaugeImage _MapBackground;
@@ -219,7 +220,12 @@ namespace GadrocsWorkshop.Helios.Controls
 			Actions.Add(_overviewPanelVisible);
 			Values.Add(_overviewPanelVisible);
 
-			_overviewRangeRingsVisible = new HeliosValue(this, new BindingValue(false), "", "Target Selection Range Rings Visible", "Sets visibility of the target selection range rings.", "Set true to show target selection range rings.", BindingValueUnits.Boolean);
+			_overviewClearTarget = new HeliosValue(this, new BindingValue(false), "", "Target Selection Clear", "Clears the selected target.", "Set true to clear the selected target.", BindingValueUnits.Boolean);
+			_overviewClearTarget.Execute += new HeliosActionHandler(OverviewClearTarget_Execute);
+			Actions.Add(_overviewClearTarget);
+			Values.Add(_overviewClearTarget);
+
+			_overviewRangeRingsVisible = new HeliosValue(this, new BindingValue(true), "", "Target Selection Range Rings Visible", "Sets visibility of the target selection range rings.", "Set true to show target selection range rings.", BindingValueUnits.Boolean);
 			_overviewRangeRingsVisible.Execute += new HeliosActionHandler(OverviewRangeRingsVisible_Execute);
 			Actions.Add(_overviewRangeRingsVisible);
 			Values.Add(_overviewRangeRingsVisible);
@@ -574,6 +580,17 @@ namespace GadrocsWorkshop.Helios.Controls
 			}
 		}
 
+		void OverviewClearTarget_Execute(object action, HeliosActionEventArgs e)
+		{
+			_overviewClearTarget.SetValue(e.Value, e.BypassCascadingTriggers);
+			bool overviewClearTarget = _overviewClearTarget.Value.BoolValue;
+
+			if (overviewClearTarget)
+			{
+				ClearSelectedTarget();
+			}
+		}
+
 		void OverviewRangeRingsVisible_Execute(object action, HeliosActionEventArgs e)
 		{
 			_overviewRangeRingsVisible.SetValue(e.Value, e.BypassCascadingTriggers);
@@ -610,7 +627,7 @@ namespace GadrocsWorkshop.Helios.Controls
 
 				if (distance <= 125)
 				{
-					if (_OverviewTarget.IsHidden)
+					if (_OverviewTarget.IsHidden || !TargetClearOnTouch)
 					{
 						if (Height >= Width)
 						{
@@ -639,27 +656,35 @@ namespace GadrocsWorkshop.Helios.Controls
 						_MapOverlays.TargetVisible = true;
 						_targetHorizontalOffset = distance_posX * _mapFeetPerNauticalMile;
 						_targetVerticalOffset = distance_posY * _mapFeetPerNauticalMile;
+
+						ProcessTargetValues(true);
+						Refresh();
 					}
 					else
 					{
-						_targetSelected = false;
-						_OverviewTarget.IsHidden = true;
-
-						_OverviewTextData.TargetSelected = false;
-						_OverviewTextData.TargetBearing = 0;
-						_OverviewTextData.TargetDistance = 0;
-
-						_OverviewTargetLines.IsHidden = true;
-						
-						_MapOverlays.TargetVisible = false;
-						_targetHorizontalOffset = 0;
-						_targetVerticalOffset = 0;
+						ClearSelectedTarget();
 					}
-
-					ProcessTargetValues(true);
-					Refresh();
 				}
 			}
+		}
+
+		void ClearSelectedTarget()
+		{
+			_targetSelected = false;
+			_OverviewTarget.IsHidden = true;
+
+			_OverviewTextData.TargetSelected = false;
+			_OverviewTextData.TargetBearing = 0;
+			_OverviewTextData.TargetDistance = 0;
+
+			_OverviewTargetLines.IsHidden = true;
+
+			_MapOverlays.TargetVisible = false;
+			_targetHorizontalOffset = 0;
+			_targetVerticalOffset = 0;
+
+			ProcessTargetValues(true);
+			Refresh();
 		}
 
 		void ResetTargetOverview()

--- a/HeliosFalcon/Controls/MapControlBehaviorEditor.xaml
+++ b/HeliosFalcon/Controls/MapControlBehaviorEditor.xaml
@@ -1,0 +1,28 @@
+﻿<HeliosSdk:HeliosPropertyEditor x:Class="GadrocsWorkshop.Helios.Controls.MapControlBehaviorEditor" 
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:HeliosSdk="clr-namespace:GadrocsWorkshop.Helios.Windows.Controls;assembly=Helios"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}"
+             mc:Ignorable="d" d:DesignHeight="50" d:DesignWidth="225">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions> 
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto" />
+            <ColumnDefinition Width="auto" />
+        </Grid.ColumnDefinitions>
+        <Label Content="Target Clear On Touch"
+               Grid.Row="1"
+               Grid.Column="0"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"/>
+        <CheckBox IsChecked="{Binding Control.TargetClearOnTouch}"
+                  Grid.Row="1"
+                  Grid.Column="1"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center" />
+    </Grid>
+</HeliosSdk:HeliosPropertyEditor>

--- a/HeliosFalcon/Controls/MapControlBehaviorEditor.xaml.cs
+++ b/HeliosFalcon/Controls/MapControlBehaviorEditor.xaml.cs
@@ -1,0 +1,33 @@
+﻿//  Copyright 2022 Helios Contributors
+//
+//  Helios is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Helios is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace GadrocsWorkshop.Helios.Controls
+{
+	using GadrocsWorkshop.Helios.ComponentModel;
+	using GadrocsWorkshop.Helios.Windows.Controls;
+
+	/// <summary>
+	/// Interaction logic for MapControlBehaviorEditor.xaml
+	/// </summary>
+
+	[HeliosPropertyEditor("Helios.Falcon.MapControl", "Target Selection")]
+	public partial class MapControlBehaviorEditor : HeliosPropertyEditor
+    {
+        public MapControlBehaviorEditor()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/HeliosFalcon/Controls/MapControls.cs
+++ b/HeliosFalcon/Controls/MapControls.cs
@@ -1,6 +1,6 @@
 ﻿//  Copyright 2014 Craig Courtney
-//  Copyright 2021 Helios Contributors
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -24,6 +24,8 @@ namespace GadrocsWorkshop.Helios.Controls
 
 	public class MapControls : Gauges.BaseGauge
 	{
+		private bool _targetClearOnTouch = false;
+
 		public string[,] _mapBaseImages = new string[,]
 		{	{ "101", "{HeliosFalcon}/Images/Maps/Aegean/Map.jpg", "1", "Aegean" },
 			{ "102", "{HeliosFalcon}/Images/Maps/Balkans/Map.jpg", "1", "Balkans, BFB 1.2.1" },
@@ -66,6 +68,24 @@ namespace GadrocsWorkshop.Helios.Controls
 
 
 		#region Properties
+
+		public bool TargetClearOnTouch
+		{
+			get
+			{
+				return _targetClearOnTouch;
+			}
+			set
+			{
+				if (_targetClearOnTouch == value)
+				{
+					return;
+				}
+				bool oldValue = _targetClearOnTouch;
+				_targetClearOnTouch = value;
+				OnPropertyChanged(nameof(TargetClearOnTouch), oldValue, value, true);
+			}
+		}
 
 		public string UserMapImage_201
 		{
@@ -852,6 +872,10 @@ namespace GadrocsWorkshop.Helios.Controls
 		{
 			base.WriteXml(writer);
 
+			writer.WriteStartElement("Settings");
+			writer.WriteElementString("TargetClearOnTouch", TargetClearOnTouch.ToString(CultureInfo.InvariantCulture));
+			writer.WriteEndElement();
+
 			writer.WriteElementString("UserMapImage_201", UserMapImage_201);
 			writer.WriteElementString("UserMapName_201", UserMapName_201);
 			writer.WriteElementString("UserMapSize_201", UserMapSize_201.ToString(CultureInfo.InvariantCulture));
@@ -906,6 +930,13 @@ namespace GadrocsWorkshop.Helios.Controls
 		public override void ReadXml(XmlReader reader)
 		{
 			base.ReadXml(reader);
+
+			if (reader.Name.Equals("Settings"))
+			{
+				reader.ReadStartElement();
+				TargetClearOnTouch = bool.Parse(reader.ReadElementString("TargetClearOnTouch"));
+				reader.ReadEndElement();
+			}
 
 			UserMapImage_201 = reader.ReadElementString("UserMapImage_201");
 			UserMapName_201 = reader.ReadElementString("UserMapName_201");

--- a/HeliosFalcon/HeliosFalcon.csproj
+++ b/HeliosFalcon/HeliosFalcon.csproj
@@ -59,17 +59,20 @@
       <DependentUpon>HUDBehaviorEditor.xaml</DependentUpon>
     </Compile>
     <Compile Include="Interfaces\RTT\IRttGeneratorHost.cs" />
-    <Compile Include="Controls\MapControl.cs" />
-    <Compile Include="Controls\MapControlMapRenderer.cs" />
-    <Compile Include="Controls\MapControlLineRenderer.cs" />
-    <Compile Include="Controls\MapControlTextRenderer.cs" />
     <Compile Include="Controls\MapControls.cs" />
+    <Compile Include="Controls\MapControlBehaviorEditor.xaml.cs">
+      <DependentUpon>MapControlBehaviorEditor.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\MapControlsUserMapEditor.xaml.cs">
       <DependentUpon>MapControlsUserMapEditor.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\MapControlsBaseMapEditor.xaml.cs">
       <DependentUpon>MapControlsBaseMapEditor.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\MapControl.cs" />
+    <Compile Include="Controls\MapControlMapRenderer.cs" />
+    <Compile Include="Controls\MapControlLineRenderer.cs" />
+    <Compile Include="Controls\MapControlTextRenderer.cs" />
     <Compile Include="Controls\MapViewer.cs" />
     <Compile Include="Controls\MapViewerRenderer.cs" />
     <Compile Include="Gauges\Altimeter.cs" />
@@ -143,6 +146,10 @@
     <Resource Include="Images\Textures\rwr.png" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Controls\MapControlBehaviorEditor.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Controls\MapControlsUserMapEditor.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Falcon Interface - Added Target Clear Binding to Target Selection:

This just does what it says but since you can now clear the selected target with a button, a touch on the control with an existing selected target now sets a new target position rather than removing the currently selected target.

The previous mode of operation, "Target Clear On Touch", can be re-enabled in the MapControl properties settings in the Helios Editor.