### PR TITLE
Embedded Viewport Visualisation in Monitor Setup Fix

### DIFF
--- a/Helios/Gauges/AH-64D/FAT/FAT.cs
+++ b/Helios/Gauges/AH-64D/FAT/FAT.cs
@@ -41,7 +41,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.FAT
             _needle = new GaugeNeedle("{Helios}/Gauges/A-10/Common/needle_a.xaml", new Point(182d, 188d), new Size(22, 165), new Point(11, 130), 0d);
             Components.Add(_needle);
 
-            Components.Add(new GaugeImage("{Helios}/Gauges/A-10/Common/gauge_bezel.png", new Rect(0d, 0d, 364d, 376d)));
+            //Components.Add(new GaugeImage("{Helios}/Gauges/A-10/Common/gauge_bezel.png", new Rect(0d, 0d, 364d, 376d)));
 
             _FreeAirTemp = new HeliosValue(this, new BindingValue(0d), "", "Temperature Gauge", "Current Free Air Temperature.", "(-70 - +50)", BindingValueUnits.Celsius);
             _FreeAirTemp.Execute += new HeliosActionHandler(FreeAirTemp_Execute);

--- a/Helios/Interfaces/DCS/AH64D/AH-64DInterface.cs
+++ b/Helios/Interfaces/DCS/AH64D/AH-64DInterface.cs
@@ -1597,7 +1597,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.AH64D
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_PLT, comm_commands.FM1_SQL.ToString("d"), "341", "1.0", "On", "0.0", "Off", "Communications Panel (Pilot)", "FM1 Squelch Switch", "%0.1f"));
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_PLT, comm_commands.FM2_SQL.ToString("d"), "342", "1.0", "On", "0.0", "Off", "Communications Panel (Pilot)", "FM2 Squelch Switch", "%0.1f"));
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_PLT, comm_commands.HF_SQL.ToString("d"), "343", "1.0", "On", "0.0", "Off", "Communications Panel (Pilot)", "HF Squelch Switch", "%0.1f"));
-            AddFunction(new Switch(this, COMM_PANEL_PLT, "346", new SwitchPosition[] { new SwitchPosition("1.0", "Hot Mic", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.5", "Vox", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.0", "PTT", comm_commands.ICS_MODE.ToString("d")) }, "Communications Panel (Pilot)", "ICS Mode Switch", "%0.1f"));
+            AddFunction(new Switch(this, COMM_PANEL_PLT, "346", new SwitchPosition[] { new SwitchPosition("1.0", "Hot Mic", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.0", "Vox", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("-1.0", "PTT", comm_commands.ICS_MODE.ToString("d")) }, "Communications Panel (Pilot)", "ICS Mode Switch", "%0.1f"));
             AddFunction(new PushButton(this, COMM_PANEL_PLT, comm_commands.IDENT.ToString("d"), "347", "Communications Panel (Pilot)", "IDENT Button"));
 
 #endregion
@@ -1629,7 +1629,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.AH64D
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_CPG, comm_commands.FM1_SQL.ToString("d"), "382", "1.0", "On", "0.0", "Off", "Communications Panel (CP/G)", "FM1 Squelch Switch", "%0.1f"));
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_CPG, comm_commands.FM2_SQL.ToString("d"), "383", "1.0", "On", "0.0", "Off", "Communications Panel (CP/G)", "FM2 Squelch Switch", "%0.1f"));
             AddFunction(Switch.CreateToggleSwitch(this, COMM_PANEL_CPG, comm_commands.HF_SQL.ToString("d"), "384", "1.0", "On", "0.0", "Off", "Communications Panel (CP/G)", "HF Squelch Switch", "%0.1f"));
-            AddFunction(new Switch(this, COMM_PANEL_CPG, "387", new SwitchPosition[] { new SwitchPosition("1.0", "Hot Mic", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.5", "Vox", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.0", "PTT", comm_commands.ICS_MODE.ToString("d")) }, "Communications Panel (CP/G)", "ICS Mode Switch", "%0.1f"));
+            AddFunction(new Switch(this, COMM_PANEL_CPG, "387", new SwitchPosition[] { new SwitchPosition("1.0", "Hot Mic", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("0.0", "Vox", comm_commands.ICS_MODE.ToString("d")), new SwitchPosition("-1.0", "PTT", comm_commands.ICS_MODE.ToString("d")) }, "Communications Panel (CP/G)", "ICS Mode Switch", "%0.1f"));
             AddFunction(new PushButton(this, COMM_PANEL_CPG, comm_commands.IDENT.ToString("d"), "388", "Communications Panel (CP/G)", "IDENT Button"));
 
 #endregion

--- a/Helios/Util/Shadow/ShadowVisual.cs
+++ b/Helios/Util/Shadow/ShadowVisual.cs
@@ -42,6 +42,12 @@ namespace GadrocsWorkshop.Helios.Util.Shadow
         public bool IsViewport => Viewport != null;
 
         /// <summary>
+        /// true if viewport location is directly on monitor, however if the Viewport is on a child, then the location
+        /// is not tracked and automatic updating is not performed.
+        /// </summary>
+        public bool IsViewportLocationReliable => Visual.Parent.Equals(Monitor);
+
+        /// <summary>
         /// map from visual child to its shadow representation
         /// </summary>
         public Dictionary<HeliosVisual, ShadowVisual> Children { get; protected set; } = new Dictionary<HeliosVisual, ShadowVisual>();

--- a/Helios/Util/Shadow/ViewportViewModel.cs
+++ b/Helios/Util/Shadow/ViewportViewModel.cs
@@ -81,6 +81,19 @@ namespace GadrocsWorkshop.Helios.Util.Shadow
             _viewport.Y = viewport.Top;
             _viewport.Width = viewport.Width;
             _viewport.Height = viewport.Height;
+
+            ///TODO: Re-visit the viewport position determination. There is certainly a proper way to get
+            ///position of the viewport on the monitor
+            Point monitorViewPointOffset = new Point(0, 0);
+            HeliosVisual visual1 = viewport;
+            while (visual1.Parent != null && !visual1.GetType().Equals("GadrocsWorkshop.Helios.Monitor"))
+            {
+                monitorViewPointOffset.X += visual1.Left;
+                monitorViewPointOffset.Y += visual1.Top;
+                visual1 = visual1.Parent;
+            }
+            _viewport.Offset(monitorViewPointOffset.X, monitorViewPointOffset.Y);
+
             Update();
         }
 

--- a/Helios/Util/Shadow/ViewportViewModel.cs
+++ b/Helios/Util/Shadow/ViewportViewModel.cs
@@ -36,7 +36,6 @@ namespace GadrocsWorkshop.Helios.Util.Shadow
             _scale = scale;
             Update(data.Monitor);
             Update(data.Visual);
-
             Data.ViewportChanged += Data_ViewportChanged;
             Data.MonitorChanged += Data_MonitorChanged;
         }
@@ -77,23 +76,7 @@ namespace GadrocsWorkshop.Helios.Util.Shadow
 
         public void Update(HeliosVisual viewport)
         {
-            _viewport.X = viewport.Left;
-            _viewport.Y = viewport.Top;
-            _viewport.Width = viewport.Width;
-            _viewport.Height = viewport.Height;
-
-            ///TODO: Re-visit the viewport position determination. There is certainly a proper way to get
-            ///position of the viewport on the monitor
-            Point monitorViewPointOffset = new Point(0, 0);
-            HeliosVisual visual1 = viewport;
-            while (visual1.Parent != null && !visual1.GetType().Equals("GadrocsWorkshop.Helios.Monitor"))
-            {
-                monitorViewPointOffset.X += visual1.Left;
-                monitorViewPointOffset.Y += visual1.Top;
-                visual1 = visual1.Parent;
-            }
-            _viewport.Offset(monitorViewPointOffset.X, monitorViewPointOffset.Y);
-
+            _viewport = viewport.CalculateWindowsDesktopRect();
             Update();
         }
 

--- a/Patching/DCS/MonitorSetupGenerator.cs
+++ b/Patching/DCS/MonitorSetupGenerator.cs
@@ -234,8 +234,20 @@ namespace GadrocsWorkshop.Helios.Patching.DCS
                 code = null;
                 return false;
             }
+            string viewportWarning = "";
+            foreach(ShadowVisual shadowVisual in _parent.Viewports)
+            {
+                if(shadowVisual.Viewport.ViewportName == viewport.Key)
+                {
+                    if (!shadowVisual.IsViewportLocationReliable)
+                    {
+                        viewportWarning = " changes to this viewport are not tracked automatically.  If changes have been made to this viewport\'s size or location, ensure a \"Reload Status\" is performed before monitor configuration is attempted.";
+                    }
+                    break;
+                }
+            }
             ConvertToDCS(ref viewportRect);
-            code = $"{viewport.Key} = {{ x = {viewportRect.Left}, y = {viewportRect.Top}, width = {viewportRect.Width}, height = {viewportRect.Height} }}";
+            code = $"{viewport.Key} = {{ x = {viewportRect.Left}, y = {viewportRect.Top}, width = {viewportRect.Width}, height = {viewportRect.Height} }}{viewportWarning}";
             lines.Add(code);
             return true;
         }


### PR DESCRIPTION
This PR helps the visualisation of viewports which are contained inside panels or gauges to be properly viewed in Monitor Setup.   Viewports which are not directly on a Helios Monitor, are not currently tracked automatically with the result that if the location or size of the viewport changes as a result of a parent gauge or panel changing, the subsequent location of the viewport will not be updated.

Updating of the model can happen by moving the actual viewport, or by closing and reopening the Monitor Setup Interface window.  Updating the information on the Interface Status window happens when the Reload Status button is pressed.

If a containing panel is rotated (as an example) incorrect viewport location is likely.  
As mentioned in several issues, the cost/benefit of tracking everything to make it automatic means that this is likely to be all that is done in this area,

In addition to the correct sizing, a flag has been introduced on the Shadow Viewport to indicate that the dimensions might be unreliable for the Viewport.  In the Interface status, such viewports are flagged as potentially needing to be manually refreshed if they have moved.

