### PR TITLE
Timer Panel - Fix for profile stop/start disables timer.

### DIFF
--- a/Helios/Controls/TimerPanel.cs
+++ b/Helios/Controls/TimerPanel.cs
@@ -112,9 +112,6 @@ namespace GadrocsWorkshop.Helios.Controls
 
             // shut down
             _timer.Stop();
-
-            // unregister to reduce circularity
-            _timer.Tick -= TimerTick;
         }
 
         private void Profile_ProfileStarted(object sender, EventArgs e)


### PR DESCRIPTION
Stopping and then restarting a profile containing a Timer Panel disables the Timer Panel timeout,