### PR TITLE
AH-64D Keyboard Unit Text Display problem with colons.

### DIFF
--- a/Helios/Controls/TimerPanel.cs
+++ b/Helios/Controls/TimerPanel.cs
@@ -131,8 +131,15 @@ namespace GadrocsWorkshop.Helios.Controls
                 return;
             }
 
-            // lazy create
-            _timer = _timer ?? new DispatcherTimer(IntervalTimespan, DispatcherPriority.Input, TimerTick, Dispatcher.CurrentDispatcher);
+            // fixes auto close not working after a stop and start of the profile
+            if(_timer != null)
+            {
+                _timer.Tick += TimerTick;
+            }
+            else
+            {
+                _timer = new DispatcherTimer(IntervalTimespan, DispatcherPriority.Input, TimerTick, Dispatcher.CurrentDispatcher);
+            }
         }
 
         private TimeSpan IntervalTimespan => TimeSpan.FromSeconds(Math.Max(_timerInterval, MINIMUM_TIME_OUT));

--- a/Helios/Gauges/AH-64D/KU/KU.cs
+++ b/Helios/Gauges/AH-64D/KU/KU.cs
@@ -60,7 +60,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.KU
             // Top Row 104 Bottom Row 334
             // Left col 39 Right Col 520 
             AddPot("Brightness Control", new Point(65d, 395d), new Size(50d, 50d), "Brightness Control Knob");
-            AddTextDisplay("Scratchpad", new Point(58d, 32d), new Size(484d, 52d), _interfaceDevice, "Scratchpad", 22, "KEYBOARD UNIT", TextHorizontalAlignment.Left, "#=$");
+            AddTextDisplay("Scratchpad", new Point(58d, 32d), new Size(484d, 52d), _interfaceDevice, "Scratchpad", 22, "KEYBOARD UNIT", TextHorizontalAlignment.Left, "#=$;!=:");
 
         }
         protected HeliosPanel AddPanel(string name, Point posn, Size size, string background, string interfaceDevice)

--- a/Helios/Interfaces/DCS/AH64D/ExportFunctions.lua
+++ b/Helios/Interfaces/DCS/AH64D/ExportFunctions.lua
@@ -11,11 +11,11 @@ function driver.processLowImportance(mainPanelDevice)
     -- structured data
     li = helios.parseIndication(15) -- 15 Pilot Keyboard Unit
     if li then
-        helios.send(2080, string.format("%s", helios.ensureString(li.Standby_text)))
+        helios.send(2080, string.format("%s", helios.ensureString(li.Standby_text):gsub(":", "!")))
     end
     li = helios.parseIndication(14) -- 14 CP/G Keyboard Unit
     if li then
-        helios.send(2081, string.format("%s", helios.ensureString(li.Standby_text)))
+        helios.send(2081, string.format("%s", helios.ensureString(li.Standby_text):gsub(":", "!")))
     end
 	if mainPanelDevice:get_argument_value(610) == -1.0 then
 		-- clear the Chaff, Flare, and threat display if the CMWS is off


### PR DESCRIPTION
Fix for https://github.com/HeliosVirtualCockpit/Helios/issues/586 which reports a problem with AH-64D Keyboard unit scratchpad data being prematurely terminated due to the export.lua allowing a colon to be sent.  The PR fixes this problem in the export and in the KU gauge.