### PR TITLE
Indicator font scaling options

### DIFF
--- a/Helios/CompositeVisual.cs
+++ b/Helios/CompositeVisual.cs
@@ -840,7 +840,7 @@ namespace GadrocsWorkshop.Helios
         protected IndicatorPushButton AddIndicatorPushButton(string name, Point posn, Size size,
             string image, string pushedImage, Color textColor, Color onTextColor, string font,
             string interfaceDeviceName, string interfaceElementName,
-            bool withText = true)
+            bool withText = true, TextScalingMode scalingMode = TextScalingMode.Legacy)
         {
             string componentName = GetComponentName(name);
             IndicatorPushButton indicator = new Helios.Controls.IndicatorPushButton
@@ -853,7 +853,8 @@ namespace GadrocsWorkshop.Helios
                 PushedImage = pushedImage,
                 Name = componentName,
                 OnTextColor = onTextColor,
-                TextColor = textColor
+                TextColor = textColor,
+                ScalingMode = scalingMode
             };
             if (withText)
             {

--- a/Helios/Controls/DualIndicatorPushButton.cs
+++ b/Helios/Controls/DualIndicatorPushButton.cs
@@ -32,12 +32,16 @@ namespace GadrocsWorkshop.Helios.Controls
         private string _additionalIndicatorText = "";
         private TextFormat _additionalTextFormat = new TextFormat();
 
+        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
         private HeliosAction _toggleAction;
         private HeliosValue _value;
 
         public DualIndicatorPushButton()
             : base("Dual Indicator Pushbutton", new Size(75, 75))
         {
+            _referenceHeight = Height;
+
             _additionalTextFormat.PropertyChanged += new System.ComponentModel.PropertyChangedEventHandler(Format_PropertyChanged);
             _additionalTextFormat.VerticalAlignment = TextVerticalAlignment.Bottom;
             _additionalTextFormat.HorizontalAlignment = TextHorizontalAlignment.Center;
@@ -145,6 +149,31 @@ namespace GadrocsWorkshop.Helios.Controls
             get { return _additionalTextFormat; }
         }
 
+        /// <summary>
+        /// backing field for property ScalingMode, contains
+        /// the selected automatic font size scaling mode
+        /// </summary>
+        private TextScalingMode _scalingMode;
+
+        /// <summary>
+        /// the height this display had when the font size was configured
+        /// </summary>
+        private double _referenceHeight;
+
+        /// <summary>
+        /// the selected automatic font size scaling mode
+        /// </summary>
+        public TextScalingMode ScalingMode
+        {
+            get => _scalingMode;
+            set
+            {
+                if (_scalingMode == value) return;
+                TextScalingMode oldValue = _scalingMode;
+                _scalingMode = value;
+                OnPropertyChanged("ScalingMode", oldValue, value, true);
+            }
+        }
         #endregion
         #region Execution
         void Format_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -179,16 +208,6 @@ namespace GadrocsWorkshop.Helios.Controls
             base.OnPropertyChanged(args);
         }
 
-        public override void ScaleChildren(double scaleX, double scaleY)
-        {
-            if (GlobalOptions.HasScaleAllText)
-            {
-                _additionalTextFormat.FontSize *= Math.Max(scaleX, scaleY);
-            }
-            base.ScaleChildren(scaleX, scaleY);
-        }
-
-
         public override void Reset()
         {
             base.Reset();
@@ -205,6 +224,40 @@ namespace GadrocsWorkshop.Helios.Controls
                 AdditionalIndicator = !AdditionalIndicator;
             }
             base.MouseDown(location);
+        }
+        // WARNING: this virtual method is called from the base constructor (indirectly)
+        protected override void PostUpdateRectangle(Rect previous, Rect current)
+        {
+            switch (ScalingMode)
+            {
+                case TextScalingMode.Height:
+                    if (_referenceHeight < 0.001)
+                    {
+                        TextFormat.FontSize = TextFormat.ConfiguredFontSize;
+                        _additionalTextFormat.FontSize = _additionalTextFormat.ConfiguredFontSize;
+                        break;
+                    }
+                    // avoid accumulating error from repeated resizing by calculating from a reference point
+                    Logger.Debug("Alternate Text scaling font based on new height {Height} versus reference {ReferenceSize} at height {ReferenceHeight}",
+                        current.Height, TextFormat.ConfiguredFontSize, _referenceHeight);
+                    TextFormat.FontSize = Clamp(TextFormat.ConfiguredFontSize * current.Height / _referenceHeight, 1, 2000);
+                    _additionalTextFormat.FontSize = Clamp(_additionalTextFormat.ConfiguredFontSize * current.Height / _referenceHeight, 1, 2000);
+                    break;
+                case TextScalingMode.None:
+                    return;
+                case TextScalingMode.Legacy:
+                    if (previous.Height != 0)
+                    {
+                        double scale = current.Height / previous.Height;
+                        TextFormat.FontSize = Clamp(scale * TextFormat.FontSize, 1, 100);
+                        _additionalTextFormat.FontSize = Clamp(scale * _additionalTextFormat.FontSize, 1, 100);
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            Logger.Debug("Alternate Font Size " + TextFormat.FontSize);
+            base.PostUpdateRectangle(previous, current);
         }
 
         public override void WriteXml(XmlWriter writer)
@@ -224,6 +277,10 @@ namespace GadrocsWorkshop.Helios.Controls
                 writer.WriteElementString("OffTextColor", colorConverter.ConvertToString(null, System.Globalization.CultureInfo.InvariantCulture, AdditionalOffTextColor));
 
                 writer.WriteEndElement();
+                if (ScalingMode != TextScalingMode.Legacy)
+                {
+                    writer.WriteElementString("ScalingMode", ScalingMode.ToString());
+                }
             }
         }
 
@@ -251,7 +308,28 @@ namespace GadrocsWorkshop.Helios.Controls
                 }
                 reader.ReadEndElement();
             }
+
+            if (reader.Name == "ScalingMode" && Enum.TryParse(reader.ReadElementString("ScalingMode"), out TextScalingMode configured))
+            {
+                ScalingMode = configured;
+            }
+            else
+            {
+                ScalingMode = TextScalingMode.Legacy;
+            }
         }
         #endregion
+        private double Clamp(double value, double min, double max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+            if (value > max)
+            {
+                return max;
+            }
+            return value;
+        }
     }
 }

--- a/Helios/Controls/DualIndicatorPushButton.cs
+++ b/Helios/Controls/DualIndicatorPushButton.cs
@@ -163,7 +163,7 @@ namespace GadrocsWorkshop.Helios.Controls
         /// <summary>
         /// the selected automatic font size scaling mode
         /// </summary>
-        public TextScalingMode ScalingMode
+        public new TextScalingMode ScalingMode
         {
             get => _scalingMode;
             set

--- a/Helios/Controls/DualIndicatorPushButtonAppearanceEditor.xaml
+++ b/Helios/Controls/DualIndicatorPushButtonAppearanceEditor.xaml
@@ -12,6 +12,7 @@
     <HeliosSdk:HeliosPropertyEditor.Resources>
         <Helios:EnumConverter Type="{x:Type Helios:TextVerticalAlignment}" x:Key="VertAlignmentTypes" />
         <Helios:EnumConverter Type="{x:Type Helios:TextHorizontalAlignment}" x:Key="HorizAlignmentTypes" />
+        <Helios:EnumConverter Type="{x:Type local:TextScalingMode}" x:Key="TextScalingModes" />
         <Helios:EnumConverter Type="{x:Type local:PushButtonGlyph}" x:Key="GlyphTypes" />
         <Style x:Key="LabelGlyphStyle" TargetType="{x:Type Label}">
             <Style.Triggers>
@@ -40,8 +41,8 @@
                     <Setter Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
             </Style.Triggers>
-        </Style>        
-    </HeliosSdk:HeliosPropertyEditor.Resources>    
+        </Style>
+    </HeliosSdk:HeliosPropertyEditor.Resources>
     <Grid Background="Transparent" Margin="4">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -52,6 +53,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -76,7 +79,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -86,132 +89,139 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="4,10,2,2" Style="{StaticResource Heading2}">Decoration</TextBlock>
-        <Label Grid.Column="0" Grid.Row="1" FontSize="10" HorizontalAlignment="Right" Content="Symbol">
+        <Label Grid.Column="0" Grid.Row="1" FontSize="10" HorizontalAlignment="Left" Content="Symbol" Margin="10,0,0,0">
             <Label.ToolTip>Symbol to be rendered on this buttom.</Label.ToolTip>
         </Label>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="4,0,0,0" FontSize="10" ItemsSource="{Binding Source={StaticResource GlyphTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.Glyph, Converter={StaticResource GlyphTypes}}" HorizontalAlignment="Left" />
-        <Label Grid.Column="0" Grid.Row="2" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Thickness">
+        <Label Grid.Row="2" FontSize="10" HorizontalAlignment="Center" Style="{StaticResource LabelGlyphStyle}" Content="Thickness" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>Thickness of the symbols lines.</Label.ToolTip>
         </Label>
-        <HeliosSdk:HeliosTextBox Grid.Column="1" Grid.Row="2" FontSize="10" Text="{Binding Control.GlyphThickness, Mode=TwoWay}" Margin="2" Style="{StaticResource TextBoxGlyphStyle}"/>
-        <Label Grid.Column="0" Grid.Row="3" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Scale">
+        <HeliosSdk:HeliosTextBox Grid.Column="1" Grid.Row="2" FontSize="10" Text="{Binding Control.GlyphThickness, Mode=TwoWay}" Margin="2,2,2,2" Style="{StaticResource TextBoxGlyphStyle}"/>
+        <Label Grid.Column="0" Grid.Row="3" FontSize="10" HorizontalAlignment="Left" Style="{StaticResource LabelGlyphStyle}" Content="Scale" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>How large will the symbol be drawn.</Label.ToolTip>
         </Label>
-        <Slider Grid.Row="3" Grid.Column="1" Minimum="0.1" Maximum="1" Value="{Binding Control.GlyphScale}" Margin="4" TickPlacement="TopLeft" TickFrequency="0.1" Style="{StaticResource SliderGlyphStyle}"/>
-
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Primary Indicator Text"/>
-        <Label Grid.Column="0" Grid.Row="5" FontSize="10" HorizontalAlignment="Right">
-            <Label.ToolTip>Text which will be rendered on the indicator.</Label.ToolTip>Texts
+        <Slider Grid.Row="3" Grid.Column="1" Minimum="0.1" Maximum="1" Value="{Binding Control.GlyphScale}" Margin="4,4,4,4" TickPlacement="TopLeft" TickFrequency="0.1" Style="{StaticResource SliderGlyphStyle}"/>
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Text Properties"/>
+        <Label Grid.Row="5" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="Auto Scaling">
+            <Label.ToolTip>How font size will be scaled if the control is scaled.</Label.ToolTip>
         </Label>
-        <HeliosSdk:HeliosTextBox  Grid.Column="1" Grid.Row="5" FontSize="10" Text="{Binding Path=Control.Text}" Margin="2" GotFocus="TurnIndicatorOn" Tag="PrimaryText" />
-        <Label Grid.Column="0" Grid.Row="6" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Font">
+        <ComboBox Grid.Column="1" Grid.Row="5" Margin="2,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource TextScalingModes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.ScalingMode, Converter={StaticResource TextScalingModes}}"/>
+
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="6" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Primary Indicator Text"/>
+        <Label Grid.Column="0" Grid.Row="7" FontSize="10" HorizontalAlignment="Center" Margin="8,0,0,0" Grid.RowSpan="1">
+            <Label.ToolTip>Text which will be rendered on the indicator.</Label.ToolTip> Text
+        </Label>
+        <HeliosSdk:HeliosTextBox  Grid.Column="1" Grid.Row="7" FontSize="10" Text="{Binding Path=Control.Text}" Margin="2,2,2,2" GotFocus="TurnIndicatorOn" Tag="PrimaryText" />
+        <Label Grid.Column="0" Grid.Row="8" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="Font" Margin="8,0,0,0">
             <Label.ToolTip>Font which will be used to render the text.</Label.ToolTip>
         </Label>
-        <HeliosSdk:TextFormatButton Grid.Column="1" Grid.Row="6" TextFormat="{Binding Control.TextFormat}" Margin="2" GotFocus="TurnIndicatorOn" Tag="PrimaryFont" />
-        <Label Grid.Column="0" Grid.Row="7" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="V Align">
+        <HeliosSdk:TextFormatButton Grid.Column="1" Grid.Row="8" TextFormat="{Binding Control.TextFormat}" Margin="2,2,2,2" GotFocus="TurnIndicatorOn" Tag="PrimaryFont" />
+        <Label Grid.Row="9" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="V Align"  >
             <Label.ToolTip>How the text will be aligned vertically inside the indicator.</Label.ToolTip>
         </Label>
-        <ComboBox Grid.Column="1" Grid.Row="7" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource VertAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.VerticalAlignment, Converter={StaticResource VertAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
-        <Label Grid.Column="0" Grid.Row="8" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="H Align">
+        <ComboBox Grid.Column="1" Grid.Row="9" Margin="2,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource VertAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.VerticalAlignment, Converter={StaticResource VertAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <Label Grid.Column="0" Grid.Row="10" FontSize="10" HorizontalAlignment="Left" Content="H Align" Margin="10,0,0,28" Grid.RowSpan="2">
             <Label.ToolTip>How the text will be aligned horizontally inside the indicator.</Label.ToolTip>
         </Label>
-        <ComboBox Grid.Column="1" Grid.Row="8" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <ComboBox Grid.Column="1" Grid.Row="10" Margin="2,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="9" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Primary Indicator Padding"/>
-        <Label Grid.Column="0" Grid.Row="10" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="11" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Primary Indicator Padding"/>
+        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Left" Margin="26,0,0,0">
             <Label.ToolTip>Amount of space on the left edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="10" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" Tag="Primary" />
-        <Label Grid.Column="0" Grid.Row="11" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
+        <Slider Grid.Row="12" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="52,2,0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" Tag="Primary" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="13" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Right" Margin="19,0,0,0">
             <Label.ToolTip>Amount of space on the right edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="11" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" Tag="Primary" />
-        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
+        <Slider Grid.Row="13" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" Tag="Primary" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="14" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Top" Margin="26,0,0,0">
             <Label.ToolTip>Amount of space on the top edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="12" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" Tag="Primary" />
-        <Label Grid.Column="0" Grid.Row="13" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
+        <Slider Grid.Row="14" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" Tag="Primary" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="15" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Bottom" Margin="9,0,0,0">
             <Label.ToolTip>Amount of space on the bottom edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="13" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" Tag="Primary" />
-        <Label Grid.Column="0" Grid.Row="14" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="On Text">
+        <Slider Grid.Row="15" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" Tag="Primary" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="16" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="On Text" Margin="9,0,0,0">
             <Label.ToolTip>Color the text will be rendered when the primary indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="14" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" Tag="PrimaryOnTextColor" />
-        <Label Grid.Column="0" Grid.Row="15" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Off Text">
+        <HeliosSdk:ColorWell Grid.Row="16" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="52,2,0,2" Tag="PrimaryOnTextColor" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="17" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Off Text" Margin="8,0,0,0">
             <Label.ToolTip>Color the text will be rendered when the primary indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="15" Color="{Binding Path=Control.TextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" Tag="PrimaryOffTextColor" />
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="16" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Additional Indicator Text"/>
-        <Label Grid.Column="0" Grid.Row="17" FontSize="10" HorizontalAlignment="Right">
-            <Label.ToolTip>Text which will be rendered as the additional indicator.</Label.ToolTip>Text
+        <HeliosSdk:ColorWell Grid.Row="17" Color="{Binding Path=Control.TextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="52,2,0,2" Tag="PrimaryOffTextColor" Grid.ColumnSpan="2" />
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="18" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Additional Indicator Text"/>
+        <Label Grid.Column="0" Grid.Row="19" FontSize="10" HorizontalAlignment="Center" Margin="8,0,0,0">
+            <Label.ToolTip>Text which will be rendered as the additional indicator.</Label.ToolTip> Text
         </Label>
-        <HeliosSdk:HeliosTextBox  Grid.Column="1" Grid.Row="17" FontSize="10" Text="{Binding Path=Control.AdditionalText}" Margin="2" GotFocus="TurnIndicatorOn" Tag="AdditionalText"/>
-        <Label Grid.Column="0" Grid.Row="18" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Font">
+        <HeliosSdk:HeliosTextBox  Grid.Column="1" Grid.Row="19" FontSize="10" Text="{Binding Path=Control.AdditionalText}" Margin="2,2,2,2" GotFocus="TurnIndicatorOn" Tag="AdditionalText"/>
+        <Label Grid.Column="0" Grid.Row="20" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="Font" Margin="8,0,0,0">
             <Label.ToolTip>Font which will be used to render the text.</Label.ToolTip>
         </Label>
-        <HeliosSdk:TextFormatButton Grid.Column="1" Grid.Row="18" TextFormat="{Binding Control.AdditionalTextFormat}" Margin="2" GotFocus="TurnIndicatorOn" Tag="AdditionalFont"/>
-        <Label Grid.Column="0" Grid.Row="19" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="V Align">
+        <HeliosSdk:TextFormatButton Grid.Column="1" Grid.Row="20" TextFormat="{Binding Control.AdditionalTextFormat}" Margin="2,2,2,2" GotFocus="TurnIndicatorOn" Tag="AdditionalFont"/>
+        <Label Grid.Row="21" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="V Align" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>How the additional text will be aligned vertically inside the indicator.</Label.ToolTip>
         </Label>
-        <ComboBox Grid.Column="1" Grid.Row="19" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource VertAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.AdditionalTextFormat.VerticalAlignment, Converter={StaticResource VertAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
-        <Label Grid.Column="0" Grid.Row="20" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="H Align">
+        <ComboBox Grid.Column="1" Grid.Row="21" Margin="2,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource VertAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.AdditionalTextFormat.VerticalAlignment, Converter={StaticResource VertAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <Label Grid.Column="0" Grid.Row="22" FontSize="10" HorizontalAlignment="Center" VerticalAlignment="Top" Content="H Align" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>How the additional text will be aligned horizontally inside the indicator.</Label.ToolTip>
         </Label>
-        <ComboBox Grid.Column="1" Grid.Row="20" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.AdditionalTextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <ComboBox Grid.Column="1" Grid.Row="22" Margin="2,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.AdditionalTextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="21" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Additional Indicator Padding"/>
-        <Label Grid.Column="0" Grid.Row="22" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="23" Margin="4,10,2,2" Style="{StaticResource Heading2}" Text="Additional Indicator Padding"/>
+        <Label Grid.Column="0" Grid.Row="24" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Left" Margin="26,0,0,0">
             <Label.ToolTip>Amount of space on the left edge where the additional text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="22" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" Tag="Additional" />
-        <Label Grid.Column="0" Grid.Row="23" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
+        <Slider Grid.Row="24" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingLeft}" Margin="52,2,0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" Tag="Additional" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="25" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Right" Margin="19,0,0,0">
             <Label.ToolTip>Amount of space on the right edge where the additional text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="23" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" Tag="Additional" />
-        <Label Grid.Column="0" Grid.Row="24" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
+        <Slider Grid.Row="25" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingRight}" IsDirectionReversed="true" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" Tag="Additional" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="26" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Top" Margin="26,0,0,0">
             <Label.ToolTip>Amount of space on the top edge where the additional text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="24" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" Tag="Additional" />
-        <Label Grid.Column="0" Grid.Row="25" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
+        <Slider Grid.Row="26" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingTop}" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" Tag="Additional" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="27" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Bottom" Margin="9,0,0,0">
             <Label.ToolTip>Amount of space on the bottom edge where the additional text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="25" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" Tag="Additional" />
-        <Label Grid.Column="0" Grid.Row="26" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="On Text">
+        <Slider Grid.Row="27" Minimum="0" Maximum="1" Value="{Binding Path=Control.AdditionalTextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="52,2,0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" Tag="Additional" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="28" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="On Text" Margin="9,0,0,0">
             <Label.ToolTip>Color the additional text will be rendered when the additional indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="26" Color="{Binding Path=Control.AdditionalOnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" Tag="AdditionalOnTextColor" />
-        <Label Grid.Column="0" Grid.Row="27" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Off Text">
+        <HeliosSdk:ColorWell Grid.Row="28" Color="{Binding Path=Control.AdditionalOnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="52,2,0,2" Tag="AdditionalOnTextColor" Grid.ColumnSpan="2" />
+        <Label Grid.Column="0" Grid.Row="29" FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Center" Content="Off Text" Margin="8,0,0,0">
             <Label.ToolTip>Color the additional text will be rendered when the additional indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="27" Color="{Binding Path=Control.AdditionalOffTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" Tag="AdditionalOffTextColor" />
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="28" Margin="4,10,2,2" Style="{StaticResource Heading2}">On Appearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="29" FontSize="10" HorizontalAlignment="Right" Content="Normal">
+        <HeliosSdk:ColorWell Grid.Row="29" Color="{Binding Path=Control.AdditionalOffTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="52,2,0,2" Tag="AdditionalOffTextColor" Grid.ColumnSpan="2" />
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="30" Margin="4,10,2,2" Style="{StaticResource Heading2}" Grid.RowSpan="1">On Appearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="30" FontSize="10" HorizontalAlignment="Left" Content="Normal" Margin="8,28,0,0" Grid.RowSpan="2">
             <Label.ToolTip>Image displayed when this push button is not pushed and the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="29" ImageFilename="{Binding Control.IndicatorOnImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="30" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
+        <HeliosSdk:ImagePicker Grid.Row="31" ImageFilename="{Binding Control.IndicatorOnImage, Mode=TwoWay}" Grid.ColumnSpan="2" Margin="52,2,0,2" Grid.RowSpan="1" />
+        <Label Grid.Column="0" Grid.Row="32" FontSize="10" HorizontalAlignment="Left" Content="Pushed" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>Image displayed when this push button is pushed and the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="30" ImageFilename="{Binding Control.PushedIndicatorOnImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="31" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
+        <HeliosSdk:ImagePicker Grid.Row="32" ImageFilename="{Binding Control.PushedIndicatorOnImage, Mode=TwoWay}" Grid.ColumnSpan="2" Margin="52,2,0,2" Grid.RowSpan="1" />
+        <Label Grid.Column="0" Grid.Row="33" FontSize="10" HorizontalAlignment="Left" Style="{StaticResource LabelGlyphStyle}" Content="Symbol" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>Color of the symbol when the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="31" Color="{Binding Control.OnGlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}" />
+        <HeliosSdk:ColorWell Grid.Row="33" Color="{Binding Control.OnGlyphColor}" HorizontalAlignment="Left" Margin="52,2,0,2" Style="{StaticResource ColorWellGlyphStyle}" Grid.ColumnSpan="2" Grid.RowSpan="1"/>
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="32" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Apearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="33" FontSize="10" HorizontalAlignment="Right" Content="Normal">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="34" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Appearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="35" FontSize="10" HorizontalAlignment="Left" Content="Normal" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>Image displayed when this push button is not pushed and the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="33" ImageFilename="{Binding Control.Image, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="34" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
+        <HeliosSdk:ImagePicker Grid.Row="35" ImageFilename="{Binding Control.Image, Mode=TwoWay}" Grid.ColumnSpan="2" Margin="52,2,0,2" Grid.RowSpan="1" />
+
+        <Label Grid.Column="0" Grid.Row="36" FontSize="10" HorizontalAlignment="Left" Content="Pushed" Margin="8,0,0,0" Grid.RowSpan="1">
             <Label.ToolTip>Image displayed when this push button is pushed and the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="34" ImageFilename="{Binding Control.PushedImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="35" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
+        <HeliosSdk:ImagePicker Grid.Row="36" ImageFilename="{Binding Control.PushedImage, Mode=TwoWay}" Grid.ColumnSpan="2" Margin="52,2,0,2" Grid.RowSpan="1" />
+
+        <Label Grid.Column="0" Grid.Row="37" FontSize="10" HorizontalAlignment="Center" Style="{StaticResource LabelGlyphStyle}" Content="Symbol" Margin="0,0,0,0">
             <Label.ToolTip>Color of the symbol when the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="35" Color="{Binding Control.GlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}"/>
+        <HeliosSdk:ColorWell Grid.Row="37" Color="{Binding Control.GlyphColor}" HorizontalAlignment="Left" Margin="52,2,0,2" Style="{StaticResource ColorWellGlyphStyle}" Grid.ColumnSpan="2" Grid.RowSpan="1"/>
 
 
     </Grid>

--- a/Helios/Controls/IndicatorAppearancePropertyEditor.xaml
+++ b/Helios/Controls/IndicatorAppearancePropertyEditor.xaml
@@ -5,13 +5,17 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              xmlns:Helios="clr-namespace:GadrocsWorkshop.Helios"
-             xmlns:HeliosSdk="clr-namespace:GadrocsWorkshop.Helios.Windows.Controls"                      
+             xmlns:HeliosSdk="clr-namespace:GadrocsWorkshop.Helios.Windows.Controls" 
+             xmlns:controls="clr-namespace:GadrocsWorkshop.Helios.Controls"
              DataContext="{Binding RelativeSource={RelativeSource Self}}"
              Height="Auto" d:DesignWidth="180">
     <HeliosSdk:HeliosPropertyEditor.Resources>
         <Helios:EnumConverter Type="{x:Type Helios:TextVerticalAlignment}" x:Key="VertAlignmentTypes" />
         <Helios:EnumConverter Type="{x:Type Helios:TextHorizontalAlignment}" x:Key="HorizAlignmentTypes" />
+        <Helios:EnumConverter Type="{x:Type controls:TextScalingMode}" x:Key="TextScalingModes" />
+
     </HeliosSdk:HeliosPropertyEditor.Resources>
+
     <Grid Background="Transparent" Margin="4">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -23,6 +27,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -37,7 +42,8 @@
         </Grid.RowDefinitions>
         <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="4,10,2,2" Style="{StaticResource Heading2}">Text</TextBlock>
         <Label Grid.Column="0" Grid.Row="1" FontSize="10" HorizontalAlignment="Right">
-            <Label.ToolTip>Text which will be rendered on the indicator.</Label.ToolTip>Text</Label>
+            <Label.ToolTip>Text which will be rendered on the indicator.</Label.ToolTip> Text
+        </Label>
         <HeliosSdk:HeliosTextBox  Grid.Column="1" Grid.Row="1" FontSize="10" Text="{Binding Path=Control.Text}" Margin="2" GotFocus="TurnIndicatorOn" />
         <Label Grid.Column="0" Grid.Row="2" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Font">
             <Label.ToolTip>Font which will be used to render the text.</Label.ToolTip>
@@ -51,44 +57,48 @@
             <Label.ToolTip>How the text will be aligned horizontally inside the indicator.</Label.ToolTip>
         </Label>
         <ComboBox Grid.Column="1" Grid.Row="4" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <Label Grid.Column="0" Grid.Row="5" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Auto Scaling">
+            <Label.ToolTip>How font size will be scaled if the control is scaled.</Label.ToolTip>
+        </Label>
+        <ComboBox Grid.Column="1" Grid.Row="5" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource TextScalingModes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.ScalingMode, Converter={StaticResource TextScalingModes}}"/>
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="5" Margin="4,10,2,2" Style="{StaticResource Heading2}">Text Padding</TextBlock>
-        <Label Grid.Column="0" Grid.Row="6" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="6" Margin="4,10,2,2" Style="{StaticResource Heading2}">Text Padding</TextBlock>
+        <Label Grid.Column="0" Grid.Row="7" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
             <Label.ToolTip>Amount of space on the left edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="6" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="7" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
+        <Slider Grid.Column="1" Grid.Row="7" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="8" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
             <Label.ToolTip>Amount of space on the right edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="7" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="8" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
+        <Slider Grid.Column="1" Grid.Row="8" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="9" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
             <Label.ToolTip>Amount of space on the top edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="8" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="9" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
+        <Slider Grid.Column="1" Grid.Row="9" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="10" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
             <Label.ToolTip>Amount of space on the bottom edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="9" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" />
+        <Slider Grid.Column="1" Grid.Row="10" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="10" Margin="4,10,2,2" Style="{StaticResource Heading2}">On Appearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="11" FontSize="10" HorizontalAlignment="Right" Content="Image">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="11" Margin="4,10,2,2" Style="{StaticResource Heading2}">On Appearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Right" Content="Image">
             <Label.ToolTip>Image which will be displayed when the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="11" ImageFilename="{Binding Control.OnImage, Mode=TwoWay}"  GotFocus="TurnIndicatorOn" />
-        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Color">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="12" ImageFilename="{Binding Control.OnImage, Mode=TwoWay}"  GotFocus="TurnIndicatorOn" />
+        <Label Grid.Column="0" Grid.Row="13" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Color">
             <Label.ToolTip>Color text will be rendered in when the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="12" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2"  GotFocus="TurnIndicatorOn" />
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="13" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2"  GotFocus="TurnIndicatorOn" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="13" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Appearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="14" FontSize="10" HorizontalAlignment="Right" Content="Image">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="14" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Appearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="15" FontSize="10" HorizontalAlignment="Right" Content="Image">
             <Label.ToolTip>Image which will be displayed when the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="14" ImageFilename="{Binding Control.OffImage, Mode=TwoWay}"  GotFocus="TurnIndicatorOff"/>
-        <Label Grid.Column="0" Grid.Row="15" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="15" ImageFilename="{Binding Control.OffImage, Mode=TwoWay}"  GotFocus="TurnIndicatorOff"/>
+        <Label Grid.Column="0" Grid.Row="16" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
             <Label.ToolTip>Color text will be rendered in when the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="15" Color="{Binding Path=Control.OffTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" GotFocus="TurnIndicatorOff" />
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="16" Color="{Binding Path=Control.OffTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" GotFocus="TurnIndicatorOff" />
 
     </Grid>
 </HeliosSdk:HeliosPropertyEditor>

--- a/Helios/Controls/IndicatorPushButtonAppearanceEditor.xaml
+++ b/Helios/Controls/IndicatorPushButtonAppearanceEditor.xaml
@@ -5,13 +5,15 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              xmlns:Helios="clr-namespace:GadrocsWorkshop.Helios"
-             xmlns:HeliosSdk="clr-namespace:GadrocsWorkshop.Helios.Windows.Controls"    
+             xmlns:HeliosSdk="clr-namespace:GadrocsWorkshop.Helios.Windows.Controls"
+             xmlns:controls="clr-namespace:GadrocsWorkshop.Helios.Controls"
              xmlns:local="clr-namespace:GadrocsWorkshop.Helios.Controls"
              DataContext="{Binding RelativeSource={RelativeSource Self}}"
              Height="Auto" d:DesignWidth="180">
     <HeliosSdk:HeliosPropertyEditor.Resources>
         <Helios:EnumConverter Type="{x:Type Helios:TextVerticalAlignment}" x:Key="VertAlignmentTypes" />
         <Helios:EnumConverter Type="{x:Type Helios:TextHorizontalAlignment}" x:Key="HorizAlignmentTypes" />
+        <Helios:EnumConverter Type="{x:Type controls:TextScalingMode}" x:Key="TextScalingModes" />
         <Helios:EnumConverter Type="{x:Type local:PushButtonGlyph}" x:Key="GlyphTypes" />
         <Style x:Key="LabelGlyphStyle" TargetType="{x:Type Label}">
             <Style.Triggers>
@@ -40,8 +42,8 @@
                     <Setter Property="Visibility" Value="Collapsed" />
                 </DataTrigger>
             </Style.Triggers>
-        </Style>        
-    </HeliosSdk:HeliosPropertyEditor.Resources>    
+        </Style>
+    </HeliosSdk:HeliosPropertyEditor.Resources>
     <Grid Background="Transparent" Margin="4">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -57,6 +59,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -104,61 +107,65 @@
             <Label.ToolTip>How the text will be aligned horizontally inside the indicator.</Label.ToolTip>
         </Label>
         <ComboBox Grid.Column="1" Grid.Row="8" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource HorizAlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.TextFormat.HorizontalAlignment, Converter={StaticResource HorizAlignmentTypes}}" GotFocus="TurnIndicatorOn" />
+        <Label Grid.Column="0" Grid.Row="9" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Auto Scaling">
+            <Label.ToolTip>How font size will be scaled if the control is scaled.</Label.ToolTip>
+        </Label>
+        <ComboBox Grid.Column="1" Grid.Row="9" Margin="2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource TextScalingModes}, Path=DisplayNames}" SelectedItem="{Binding Path=Control.ScalingMode, Converter={StaticResource TextScalingModes}}"/>
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="9" Margin="4,10,2,2" Style="{StaticResource Heading2}">Text Padding</TextBlock>
-        <Label Grid.Column="0" Grid.Row="10" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="10" Margin="4,10,2,2" Style="{StaticResource Heading2}">Text Padding</TextBlock>
+        <Label Grid.Column="0" Grid.Row="11" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Left">
             <Label.ToolTip>Amount of space on the left edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="10" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="11" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
+        <Slider Grid.Column="1" Grid.Row="11" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingLeft}" Margin="0,2" GotFocus="TurnIndicatorOn" ValueChanged="LeftPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Right">
             <Label.ToolTip>Amount of space on the right edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="11" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="12" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
+        <Slider Grid.Column="1" Grid.Row="12" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingRight}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="RightPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="13" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Top">
             <Label.ToolTip>Amount of space on the top edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="12" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" />
-        <Label Grid.Column="0" Grid.Row="13" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
+        <Slider Grid.Column="1" Grid.Row="13" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingTop}" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="TopPaddingChanged" />
+        <Label Grid.Column="0" Grid.Row="14" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top" Content="Bottom">
             <Label.ToolTip>Amount of space on the bottom edge where text will not be rendered. Hold shift to move individually.</Label.ToolTip>
         </Label>
-        <Slider Grid.Column="1" Grid.Row="13" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" />
+        <Slider Grid.Column="1" Grid.Row="14" Minimum="0" Maximum="1" Value="{Binding Path=Control.TextFormat.PaddingBottom}" IsDirectionReversed="true" Margin="0,2" GotFocus="TurnIndicatorOn"  ValueChanged="BottomPaddingChanged" />
 
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="14" Margin="4,10,2,2" Style="{StaticResource Heading2}">On Appearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="15" FontSize="10" HorizontalAlignment="Right" Content="Normal">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="15" Margin="4,10,2,2" Style="{StaticResource Heading2}">On Appearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="16" FontSize="10" HorizontalAlignment="Right" Content="Normal">
             <Label.ToolTip>Image displayed when this push button is not pushed and the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="15" ImageFilename="{Binding Control.IndicatorOnImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="16" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="16" ImageFilename="{Binding Control.IndicatorOnImage, Mode=TwoWay}" />
+        <Label Grid.Column="0" Grid.Row="17" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
             <Label.ToolTip>Image displayed when this push button is pushed and the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="16" ImageFilename="{Binding Control.PushedIndicatorOnImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="17" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="17" ImageFilename="{Binding Control.PushedIndicatorOnImage, Mode=TwoWay}" />
+        <Label Grid.Column="0" Grid.Row="18" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
             <Label.ToolTip>Color the text will be rendered when the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="17" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" />
-        <Label Grid.Column="0" Grid.Row="18" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="18" Color="{Binding Path=Control.OnTextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" />
+        <Label Grid.Column="0" Grid.Row="19" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
             <Label.ToolTip>Color of the symbol when the indicator is on.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="18" Color="{Binding Control.OnGlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}" />
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="19" Color="{Binding Control.OnGlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="19" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Apearance</TextBlock>
-        <Label Grid.Column="0" Grid.Row="20" FontSize="10" HorizontalAlignment="Right" Content="Normal">
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="20" Margin="4,10,2,2" Style="{StaticResource Heading2}">Off Apearance</TextBlock>
+        <Label Grid.Column="0" Grid.Row="21" FontSize="10" HorizontalAlignment="Right" Content="Normal">
             <Label.ToolTip>Image displayed when this push button is not pushed and the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="20" ImageFilename="{Binding Control.Image, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="21" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="21" ImageFilename="{Binding Control.Image, Mode=TwoWay}" />
+        <Label Grid.Column="0" Grid.Row="22" FontSize="10" HorizontalAlignment="Right" Content="Pushed">
             <Label.ToolTip>Image displayed when this push button is pushed and the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="21" ImageFilename="{Binding Control.PushedImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="22" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="22" ImageFilename="{Binding Control.PushedImage, Mode=TwoWay}" />
+        <Label Grid.Column="0" Grid.Row="23" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Center" Content="Text">
             <Label.ToolTip>Color the text will be rendered when the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="22" Color="{Binding Path=Control.TextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" />
-        <Label Grid.Column="0" Grid.Row="23" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="23" Color="{Binding Path=Control.TextColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" />
+        <Label Grid.Column="0" Grid.Row="24" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelGlyphStyle}" Content="Symbol">
             <Label.ToolTip>Color of the symbol when the indicator is off.</Label.ToolTip>
         </Label>
-        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="23" Color="{Binding Control.GlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}"/>
+        <HeliosSdk:ColorWell Grid.Column="1" Grid.Row="24" Color="{Binding Control.GlyphColor}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource ColorWellGlyphStyle}"/>
 
 
     </Grid>

--- a/Helios/Gauges/AV-8B/Advisory Panel/advisory_Panel.cs
+++ b/Helios/Gauges/AV-8B/Advisory Panel/advisory_Panel.cs
@@ -144,6 +144,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AV8B
                 indicator.TextFormat.PaddingBottom = 0;
                 indicator.TextFormat.VerticalAlignment = TextVerticalAlignment.Center;
                 indicator.TextFormat.HorizontalAlignment = TextHorizontalAlignment.Center;
+                indicator.ScalingMode = TextScalingMode.Height;
             }
 
 

--- a/Helios/Gauges/AV-8B/UFC/UFC_AV8B.cs
+++ b/Helios/Gauges/AV-8B/UFC/UFC_AV8B.cs
@@ -304,6 +304,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AV8B
             indicator.PushedImage = "{Helios}/Images/Indicators/indicator-push.png";
             indicator.Text = name;
             indicator.Name = name;
+            indicator.ScalingMode = TextScalingMode.Height;
             if (name == "MASTER WARNING")
             {
                 indicator.OnTextColor = Color.FromArgb(0xff, 0xc7, 0x1e, 0x1e);


### PR DESCRIPTION
Adopt the TextScalingModes used by the Text control to Indicator, PushbuttonIndicator, and DualPushButtonIndicator controls.
This allows more accurate / usable text scaling on these controls as well as in composite visuals embedding these controls.
Also added this option to the AV-8B warning indicators on the UFC