### PR TITLE
Add Global Path Variables to Lua Interpreter and Environmental Path Variables to Process Control

### DIFF
--- a/Helios/ConfigManager.cs
+++ b/Helios/ConfigManager.cs
@@ -1,5 +1,6 @@
 ﻿//  Copyright 2014 Craig Courtney
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -13,14 +14,14 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using System.IO;
 using System.Windows;
+using System.Collections.Generic;
+using Microsoft.Win32;
 
 namespace GadrocsWorkshop.Helios
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-
     public class ConfigManager
     {
         private static string _documentPath;
@@ -32,6 +33,7 @@ namespace GadrocsWorkshop.Helios
         {
             string assemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
             ApplicationPath = Path.GetDirectoryName(assemblyLocation);
+            BMSFalconPath = GetBMSFalconPath();
         }
 
         #region Properties
@@ -111,6 +113,7 @@ namespace GadrocsWorkshop.Helios
         public static string ProfilePath { get; private set; }
         public static string ImagePath { get; private set; }
         public static string TemplatePath { get; private set; }
+        public static string BMSFalconPath { get; private set; }
 
         public static IImageManager ImageManager { get; internal set; }
 
@@ -135,6 +138,34 @@ namespace GadrocsWorkshop.Helios
         /// private fonts for use in Helios
         /// </summary>
         public static FontManager FontManager { get; internal set; }
+
         #endregion
+
+        private static string GetBMSFalconPath()
+        {
+            RegistryKey pathKey;
+            string[] subkeys;
+            string falconRootKey = @"SOFTWARE\WOW6432Node\Benchmark Sims\";
+            string falconVersion = "";
+            string pathValue = "";
+
+            if (Registry.LocalMachine.OpenSubKey(falconRootKey) != null)
+            {
+                subkeys = Registry.LocalMachine.OpenSubKey(falconRootKey).GetSubKeyNames();
+                if (subkeys.Length > 0)
+                {
+                    Array.Reverse(subkeys);
+                    falconVersion = subkeys[0];
+                }
+            }
+
+            pathKey = Registry.LocalMachine.OpenSubKey(falconRootKey + falconVersion);
+
+            if (pathKey != null)
+            {
+                pathValue = (string)pathKey.GetValue("baseDir") ?? "";
+            }
+            return pathValue;
+        }
     }
 }

--- a/Helios/Controls/BacklitPushButton.cs
+++ b/Helios/Controls/BacklitPushButton.cs
@@ -92,7 +92,7 @@ namespace GadrocsWorkshop.Helios.Controls
             Actions.Add(_pushAction);
             Actions.Add(_releaseAction);
 
-            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed(either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
+            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed (either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
             _pushedValue.Execute += new HeliosActionHandler(PushedValue_Execute);
             Values.Add(_pushedValue);
             Actions.Add(_pushedValue);

--- a/Helios/Controls/PushButton.cs
+++ b/Helios/Controls/PushButton.cs
@@ -94,7 +94,7 @@ namespace GadrocsWorkshop.Helios.Controls
             Actions.Add(_pushAction);
             Actions.Add(_releaseAction);
 
-            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed(either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
+            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed (either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
             _pushedValue.Execute += new HeliosActionHandler(PushedValue_Execute);
             Values.Add(_pushedValue);
             Actions.Add(_pushedValue);

--- a/Helios/Controls/RotaryEncoderPushable.cs
+++ b/Helios/Controls/RotaryEncoderPushable.cs
@@ -59,7 +59,7 @@ namespace GadrocsWorkshop.Helios.Controls
             Actions.Add(_pushAction);
             Actions.Add(_releaseAction);
 
-            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed(either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
+            _pushedValue = new HeliosValue(this, new BindingValue(false), "", "physical state", "Current state of this button.", "True if the button is currently pushed (either via pressure or toggle), otherwise false.  Setting this value will not fire pushed/released triggers, but will fire on/off triggers.  Directly setting this state to on for a momentary buttons will not auto release, the state must be manually reset to false.", BindingValueUnits.Boolean);
             _pushedValue.Execute += new HeliosActionHandler(PushedValue_Execute);
             Values.Add(_pushedValue);
             Actions.Add(_pushedValue);

--- a/Helios/HeliosBinding.cs
+++ b/Helios/HeliosBinding.cs
@@ -1,6 +1,6 @@
 ﻿//  Copyright 2014 Craig Courtney
-//  Copyright 2020 Helios Contributors
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -271,13 +271,16 @@ namespace GadrocsWorkshop.Helios
                 if (_luaInterpreter == null)
                 {
                     _luaInterpreter = new Lua();
+
+                    // add lua environment variables
+                    _luaInterpreter.DoString("HeliosPath = " + "'" + ConfigManager.DocumentPath.Replace("\\", "\\\\") + "'");
+                    _luaInterpreter.DoString("BMSFalconPath = " + "'" + ConfigManager.BMSFalconPath.Replace("\\", "\\\\") + "'");
                 }
                 return _luaInterpreter;
             }
         }
 
         #endregion
-
 
         private string ReplaceValue(string inputString)
         {

--- a/Helios/Interfaces/DCS/Common/IndicatorPushButton.cs
+++ b/Helios/Interfaces/DCS/Common/IndicatorPushButton.cs
@@ -80,7 +80,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.Common
 
             _value = new HeliosValue(SourceInterface, BindingValue.Empty, SerializedDeviceName, SerializedFunctionName,
                 "Current state of this button.",
-                "True if the button is currently pushed(either via pressure or toggle), otherwise false.",
+                "True if the button is currently pushed (either via pressure or toggle), otherwise false.",
                 BindingValueUnits.Boolean);
             Values.Add(_value);
             Triggers.Add(_value);

--- a/Helios/Interfaces/DCS/Common/PushButton.cs
+++ b/Helios/Interfaces/DCS/Common/PushButton.cs
@@ -83,7 +83,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.Common
 
             _value = new HeliosValue(SourceInterface, new BindingValue(false), SerializedDeviceName, SerializedFunctionName,
                 SerializedDescription,
-                "True if the button is currently pushed(either via pressure or toggle), otherwise false.",
+                "True if the button is currently pushed (either via pressure or toggle), otherwise false.",
                 BindingValueUnits.Boolean);
             Values.Add(_value);
             Triggers.Add(_value);

--- a/HeliosProcessControl/ProcessControlInterface.cs
+++ b/HeliosProcessControl/ProcessControlInterface.cs
@@ -45,6 +45,10 @@ namespace GadrocsWorkshop.Helios.HeliosProcessControl
             HeliosAction killApplication = new HeliosAction(this, "", "", "kill application", "Kills an external process", "Process Image name of the process to be killed.", BindingValueUnits.Text);
             killApplication.Execute += KillApplication_Execute;
             Actions.Add(killApplication);
+
+            // Add environmental variables for this process only.
+            SetEnvironmentVariable("HeliosPath", ConfigManager.DocumentPath);
+            SetEnvironmentVariable("BMSFalconPath", ConfigManager.BMSFalconPath);
         }
 
         protected override void AttachToProfileOnMainThread()
@@ -338,6 +342,14 @@ namespace GadrocsWorkshop.Helios.HeliosProcessControl
             // Possibly a URI
             return ExtractURICheck(proposedPath);
         }
+
+        private void SetEnvironmentVariable(string envVar, string envVarPath)
+		{
+            if (Environment.GetEnvironmentVariable(envVar) == null)
+			{
+                Environment.SetEnvironmentVariable(envVar, envVarPath);
+            }
+		}
 
         public IEnumerable<StatusReportItem> PerformReadyCheck()
         {

--- a/HeliosProcessControl/ProcessControlInterfaceEditor.xaml
+++ b/HeliosProcessControl/ProcessControlInterfaceEditor.xaml
@@ -33,11 +33,19 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Text="{Binding Data.Name}"/>
         <!-- if there was any XML config, it would be here: <TextBlock Grid.Row="1" Text="{Binding Data.Model.xyz}"/> -->
         <ItemsControl Grid.Row="2" Margin="12,0,0,0" ItemsSource="{Binding Data.InputBindings}"/>
-        <CheckBox Grid.Row="3" IsChecked="{Binding Data.Model.AllowLaunch}" Margin="12">Allow Helios profiles on this computer to start (launch) external programs</CheckBox>
-        <CheckBox Grid.Row="4" IsChecked="{Binding Data.Model.AllowKill}" Margin="12">Allow Helios profiles on this computer to stop (kill) external programs</CheckBox>
+        <CheckBox Grid.Row="3" IsChecked="{Binding Data.Model.AllowLaunch}" Margin="12">Allow Helios profiles on this computer to start (launch) external applications.</CheckBox>
+        <CheckBox Grid.Row="4" IsChecked="{Binding Data.Model.AllowKill}" Margin="12">Allow Helios profiles on this computer to stop (kill) external applications.</CheckBox>
+        <TextBlock Grid.Row="5" Text="All standard environmental variables, of the form %EnvVarName%, are available for use in the launch applications path." />
+        <TextBlock Grid.Row="6" Text="In addition the following environmental variables are available:" />
+        <TextBlock Grid.Row="7" Text="%HeliosPath% which returns the path to the current Helios/HeliosDev folder in documents." />
+        <TextBlock Grid.Row="8" Text="%BMSFalconPath% which returns the path to the BMS Falcon root folder providing the application is installed." />
     </Grid>
 </controls:HeliosInterfaceEditor>

--- a/Profile Editor/BindingsPanel.xaml
+++ b/Profile Editor/BindingsPanel.xaml
@@ -5,7 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:helios="clr-namespace:GadrocsWorkshop.Helios;assembly=Helios"
              xmlns:local="clr-namespace:GadrocsWorkshop.Helios.ProfileEditor"
-             xmlns:vm="clr-namespace:GadrocsWorkshop.Helios.ProfileEditor.ViewModel"             
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="600" Background="{StaticResource ToolBackground}">
     <UserControl.Resources>
@@ -136,9 +135,29 @@
                                             </MultiDataTrigger.Conditions>
                                             <Setter Property="Visibility" Value="Visible" />
                                         </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <StackPanel Grid.Column="0">
+                                <TextBlock Style="{StaticResource PropertyName}">Trigger Value</TextBlock>
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="100">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding SelectedBinding.Trigger.Unit.LongName}" />
+                                        <TextBlock Text="{Binding SelectedBinding.Trigger.TriggerValueDescription}" TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </ScrollViewer>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="0" BorderBrush="#FF808080" BorderThickness="1" CornerRadius="2" Margin="4" Padding="4">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
                                         <MultiDataTrigger>
                                             <MultiDataTrigger.Conditions>
                                                 <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="LuaScript"/>
+                                                <Condition Binding="{Binding Path=BMSFalconPathExists}" Value="False"/>
                                                 <Condition Binding="{Binding SelectedBinding.Trigger.TriggerSuppliesValue}" Value="True"/>
                                             </MultiDataTrigger.Conditions>
                                             <Setter Property="Visibility" Value="Visible" />
@@ -148,10 +167,43 @@
                             </Border.Style>
                             <StackPanel Grid.Column="0">
                                 <TextBlock Style="{StaticResource PropertyName}">Trigger Value</TextBlock>
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="80">
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="100">
                                     <StackPanel>
                                         <TextBlock Text="{Binding SelectedBinding.Trigger.Unit.LongName}" />
                                         <TextBlock Text="{Binding SelectedBinding.Trigger.TriggerValueDescription}" TextWrapping="Wrap" />
+                                        <TextBlock Text="HeliosPath" TextWrapping="Wrap" />
+                                        <TextBlock Text="returns Helios Path." TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </ScrollViewer>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="0" BorderBrush="#FF808080" BorderThickness="1" CornerRadius="2" Margin="4" Padding="4">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="LuaScript"/>
+                                                <Condition Binding="{Binding Path=BMSFalconPathExists}" Value="True"/>
+                                                <Condition Binding="{Binding SelectedBinding.Trigger.TriggerSuppliesValue}" Value="True"/>
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <StackPanel Grid.Column="0">
+                                <TextBlock Style="{StaticResource PropertyName}">Trigger Value</TextBlock>
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="100">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding SelectedBinding.Trigger.Unit.LongName}" />
+                                        <TextBlock Text="{Binding SelectedBinding.Trigger.TriggerValueDescription}" TextWrapping="Wrap" />
+                                        <TextBlock Text="HeliosPath" TextWrapping="Wrap" />
+                                        <TextBlock Text="returns Helios Path." TextWrapping="Wrap" />
+                                        <TextBlock Text="BMSFalconPath" TextWrapping="Wrap" />
+                                        <TextBlock Text="returns BMS Falcon Path." TextWrapping="Wrap" />
                                     </StackPanel>
                                 </ScrollViewer>
                             </StackPanel>
@@ -160,7 +212,7 @@
                         <Border Grid.Column="1" Grid.Row="1" BorderBrush="#FF808080" BorderThickness="1" CornerRadius="2" Margin="4" Padding="4">
                             <StackPanel>
                                 <TextBlock Style="{StaticResource PropertyName}">Action Value</TextBlock>
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="80">
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" MaxHeight="100">
                                     <StackPanel>
                                         <TextBlock Text="{Binding SelectedBinding.Action.Unit.LongName}" />
                                         <TextBlock Text="{Binding SelectedBinding.Action.ActionValueDescription}" TextWrapping="Wrap" />
@@ -180,7 +232,7 @@
                                         <Style.Triggers>
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="LuaScript"/>
+                                                    <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="TriggerValue"/>
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible" />
                                             </MultiDataTrigger>
@@ -188,6 +240,48 @@
                                     </Style>
                                 </TextBlock.Style>
                                 <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger.</TextBlock.Text>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
+                            <TextBlock FontSize="10" TextWrapping="Wrap" Margin="4,4,4,0" Text="{Binding SelectedBinding.ErrorMessage}" Foreground="Red" Style="{StaticResource ErrorMessageStyle}" />
+                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource Documentation}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="LuaScript"/>
+                                                    <Condition Binding="{Binding Path=BMSFalconPathExists}" Value="False"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger. A global variable named "HeliosPath" will be populated with the Helios Path value.</TextBlock.Text>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
+                            <TextBlock FontSize="10" TextWrapping="Wrap" Margin="4,4,4,0" Text="{Binding SelectedBinding.ErrorMessage}" Foreground="Red" Style="{StaticResource ErrorMessageStyle}" />
+                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource Documentation}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding SelectedBinding.ValueSource}" Value="LuaScript"/>
+                                                    <Condition Binding="{Binding Path=BMSFalconPathExists}" Value="True"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger. Global variables named "HeliosPath" and "BMSFalconPath" will be populated with the Helios and BMS Falcon Path values respectively.</TextBlock.Text>
                             </TextBlock>
                         </StackPanel>
                     </Grid>

--- a/Profile Editor/BindingsPanel.xaml.cs
+++ b/Profile Editor/BindingsPanel.xaml.cs
@@ -1,5 +1,6 @@
 ﻿//  Copyright 2014 Craig Courtney
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -120,6 +121,11 @@ namespace GadrocsWorkshop.Helios.ProfileEditor
         // Using a DependencyProperty as the backing store for ValueEditor.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty ValueEditorProperty =
             DependencyProperty.Register("ValueEditor", typeof(StaticValueEditor), typeof(BindingsPanel), new PropertyMetadata(null));
+
+        public bool BMSFalconPathExists
+        {
+            get => ConfigManager.BMSFalconPath.Length > 0;
+        }
 
         #endregion
 


### PR DESCRIPTION
Add HeliosPath and BMSFalconPath global variables to each Binding Lua Interpreter Instance.

Add %HeliosPath% and %BMSFalconPath% environmental variables to the process control interface.