### PR TITLE
Fix for #675 to resolve default text on RockerSwitch reappearing afte…

### DIFF
--- a/Helios/Controls/RockerSwitch.cs
+++ b/Helios/Controls/RockerSwitch.cs
@@ -289,6 +289,9 @@ namespace GadrocsWorkshop.Helios.Controls
                 // now the auto scaling has messed up our font size, so we restore it
                 TextFormat.FontSize = TextFormat.ConfiguredFontSize;
                 _referenceHeight = Height;
+            } else
+            {
+                Text = "";
             }
 
         }


### PR DESCRIPTION
Fix for #675 to resolve default text on RockerSwitch reappearing after it has been deleted.  The problem was related to the fact that the a null Text string was not persisted to the profile, so the default value came from the initialization of the control when there is no Text to the deserialized.