### PR TITLE
Profile Editor - Property Editor control name validation message revised and dash character allowed

### DIFF
--- a/Helios/Controls/RotarySwitch.cs
+++ b/Helios/Controls/RotarySwitch.cs
@@ -1,6 +1,6 @@
 ﻿//  Copyright 2014 Craig Courtney
-//  Copyright 2020 Helios Contributors
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -48,6 +48,8 @@ namespace GadrocsWorkshop.Helios.Controls
         private Color _labelColor = Colors.White;
         private readonly HeliosValue _positionValue;
         private readonly HeliosValue _positionNameValue;
+        private readonly HeliosValue _incrementValue;
+        private readonly HeliosValue _decrementValue;
 
         private bool _isContinuous;
 
@@ -68,6 +70,14 @@ namespace GadrocsWorkshop.Helios.Controls
             Values.Add(_positionValue);
             Actions.Add(_positionValue);
             Triggers.Add(_positionValue);
+
+            _incrementValue = new HeliosValue(this, new BindingValue(1), "", "increment", "Increment current position of the switch.", "Set true to increment position.", BindingValueUnits.Boolean);
+            _incrementValue.Execute += IncrementPositionAction_Execute;
+            Actions.Add(_incrementValue);
+
+            _decrementValue = new HeliosValue(this, new BindingValue(1), "", "decrement", "Decrement current position of the switch.", "Set true to decrement position.", BindingValueUnits.Boolean);
+            _decrementValue.Execute += DecrementPositionAction_Execute;
+            Actions.Add(_decrementValue);
 
             _positionNameValue = new HeliosValue(this, new BindingValue("0"), "", "position name", "Name of the current position of the switch.", "", BindingValueUnits.Text);
             Values.Add(_positionNameValue);
@@ -601,6 +611,40 @@ namespace GadrocsWorkshop.Helios.Controls
                 {
                     CurrentPosition = index;
                 }
+            }
+            EndTriggerBypass(e.BypassCascadingTriggers);
+        }
+
+        void IncrementPositionAction_Execute(object action, HeliosActionEventArgs e)
+        {
+            int newPosition = CurrentPosition + 1;
+
+            BeginTriggerBypass(e.BypassCascadingTriggers);
+            // WARNING: rotary switch positions are 1-based
+            if (newPosition <= Positions.Count)
+            {
+                CurrentPosition = newPosition;
+            }
+            else if (IsContinuous)
+            {
+                CurrentPosition = 1;
+            }
+            EndTriggerBypass(e.BypassCascadingTriggers);
+        }
+
+        void DecrementPositionAction_Execute(object action, HeliosActionEventArgs e)
+        {
+            int newPosition = CurrentPosition - 1;
+
+            BeginTriggerBypass(e.BypassCascadingTriggers);
+            // WARNING: rotary switch positions are 1-based
+            if (newPosition >= 1)
+            {
+                CurrentPosition = newPosition;
+            }
+            else if (IsContinuous)
+            {
+                CurrentPosition = Positions.Count;
             }
             EndTriggerBypass(e.BypassCascadingTriggers);
         }

--- a/Profile Editor/PropertyEditors/LayoutPropertyEditor.xaml
+++ b/Profile Editor/PropertyEditors/LayoutPropertyEditor.xaml
@@ -69,7 +69,7 @@
         <Label Grid.Column="0" Grid.Row="0" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource VisibleIfControlTypeNameSet}">Control</Label>
         <Label Grid.Column="1" Grid.Row="0" FontSize="10" Content="{Binding ControlTypeName}" Style="{StaticResource VisibleIfControlTypeNameSet}"/>
         <Label Grid.Column="0" Grid.Row="1" FontSize="10" HorizontalAlignment="Right">Name</Label>
-        <HeliosSdk:HeliosTextBox Grid.Column="1" Grid.Row="1" VerticalContentAlignment="Center" FontSize="10" Margin="2" Text="{Binding VisualName, ValidatesOnDataErrors=True}" />
+        <HeliosSdk:HeliosTextBox Grid.Column="1" Grid.Row="1" VerticalContentAlignment="Center" FontSize="10" Margin="2" Text="{Binding VisualName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" />
         <Label Grid.Column="0" Grid.Row="2" FontSize="10" HorizontalAlignment="Right">Left</Label>
         <HeliosSdk:HeliosTextBox Grid.Column="1" Grid.Row="2" VerticalContentAlignment="Center" FontSize="10" Text="{Binding Path=Control.Left, Mode=TwoWay}" Margin="2" />
         <Label Grid.Column="0" Grid.Row="3" FontSize="10" HorizontalAlignment="Right">Top</Label>

--- a/Profile Editor/PropertyEditors/LayoutPropertyEditor.xaml.cs
+++ b/Profile Editor/PropertyEditors/LayoutPropertyEditor.xaml.cs
@@ -1,5 +1,6 @@
 //  Copyright 2014 Craig Courtney
-//    
+//  Copyright 2022 Helios Contributors
+//
 //  Helios is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -124,6 +125,8 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.PropertyEditors
         {
             get
             {
+                string result = "Name cannot be blank or contain special characters and must be unique.";
+
                 if (!columnName.Equals("VisualName"))
                 {
                     return null;
@@ -131,18 +134,18 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.PropertyEditors
 
                 if (string.IsNullOrWhiteSpace(VisualName))
                 {
-                    return "Name cannot be blank.";
+                    return result;
                 }
 
-                if (!Regex.IsMatch(VisualName, "^[a-zA-Z0-9_ ]*$"))
+                if (!Regex.IsMatch(VisualName, "^[a-zA-Z0-9-_ ]*$"))
                 {
-                    return "Name must not contain special characters.";
+                    return result;
                 }
 
                 if (Control != null && Control.Parent != null && !VisualName.Equals(Control.Name) &&
                     Control.Parent.Children.ContainsKey(VisualName))
                 {
-                    return "Name must be unique.";
+                    return result;
                 }
 
                 return null;


### PR DESCRIPTION
This addresses issue #686 
Profile Editor - Controls LayoutPropertyEditor returns "Name cannot be blank" for all Name Validations.

It's not a perfect solution but is certainly more intuitive for the user than the previous version which applied the same usually incorrect validation message for all control name errors,

This also allows the use of the dash character in the control name since many of the existing controls already have this in their name,  