### PR TITLE
Fix to re-establish the _timer.Tick routine on the Unhide

### DIFF
--- a/Helios/Controls/TimerPanel.cs
+++ b/Helios/Controls/TimerPanel.cs
@@ -189,7 +189,15 @@ namespace GadrocsWorkshop.Helios.Controls
                     // just shown, start time out
                     if (TimerEnabled)
                     {
-                        if (_timer == null) _timer = new DispatcherTimer(IntervalTimespan, DispatcherPriority.Input, TimerTick, Dispatcher.CurrentDispatcher);
+                        if (_timer == null)
+                        {
+                            _timer = new DispatcherTimer(IntervalTimespan, DispatcherPriority.Input, TimerTick, Dispatcher.CurrentDispatcher);
+                        }
+                        else
+                        {
+                            _timer.Tick += TimerTick;
+                        }
+                        _timer.IsEnabled = true;
                         _timer.Interval = IntervalTimespan;
                         _timer.Start();
                     }


### PR DESCRIPTION
This relates to the problem described in #691 which was caused by a fix in 1.6.5501 cleaning up the timer pop routine, but then when the unhide happed, the routine was not restored.