### PR TITLE
Profile chaining - Giving Up Control to a New Profile

### DIFF
--- a/Control Center/MainWindow.xaml.cs
+++ b/Control Center/MainWindow.xaml.cs
@@ -597,6 +597,7 @@ namespace GadrocsWorkshop.Helios.ControlCenter
             ActiveProfile.ProfileHintReceived += Profile_ProfileHintReceived;
             ActiveProfile.DriverStatusReceived += Profile_DriverStatusReceived;
             ActiveProfile.ClientChanged += Profile_ClientChanged;
+            ActiveProfile.ControlCenterChangeProfile += Profile_ChangeProfileControlCenter;
 
             ActiveProfile.Start();
 
@@ -712,6 +713,27 @@ namespace GadrocsWorkshop.Helios.ControlCenter
                 _lastProfileHint = "";
             }
             _lastDriverStatus = "";
+        }
+
+        private void Profile_ChangeProfileControlCenter(object sender, EventArgs e)
+        {
+            HeliosActionEventArgs newProfile = (HeliosActionEventArgs)e;
+            String newProfilePath = newProfile.Value.StringValue;
+            if (!newProfilePath.ToLower().Contains("\\"))
+            {
+                if (!newProfilePath.ToLower().Contains("heliospath"))
+                {
+                    newProfilePath = $@"heliospath\profiles\{newProfilePath}";
+                }
+                newProfilePath = newProfilePath.ToLower().Replace("heliospath", ConfigManager.DocumentPath.Replace("\\", "\\\\"));
+            }
+            if (!newProfilePath.ToLower().EndsWith(".hpf"))
+            {
+                newProfilePath += ".hpf";
+            }
+            StopProfile();
+            LoadProfile(newProfilePath, false);
+            StartProfile();
         }
 
         private void StopProfile()

--- a/Helios/ConfigManager.cs
+++ b/Helios/ConfigManager.cs
@@ -25,6 +25,7 @@ namespace GadrocsWorkshop.Helios
     public class ConfigManager
     {
         private static string _documentPath;
+        private static string _profileName;
 
         /// <summary>
         /// Private constructor to prevent instances.  This class is a Singleton which should be accessed
@@ -34,10 +35,15 @@ namespace GadrocsWorkshop.Helios
             string assemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
             ApplicationPath = Path.GetDirectoryName(assemblyLocation);
             BMSFalconPath = GetBMSFalconPath();
+            ProfileName = ""; 
         }
 
         #region Properties
-
+        public static string ProfileName
+        {
+            get => _profileName;
+            set => _profileName = value;
+        }
         public static string DocumentPath
         {
             get => _documentPath;

--- a/Helios/HeliosBinding.cs
+++ b/Helios/HeliosBinding.cs
@@ -275,6 +275,7 @@ namespace GadrocsWorkshop.Helios
                     // add lua environment variables
                     _luaInterpreter.DoString("HeliosPath = " + "'" + ConfigManager.DocumentPath.Replace("\\", "\\\\") + "'");
                     _luaInterpreter.DoString("BMSFalconPath = " + "'" + ConfigManager.BMSFalconPath.Replace("\\", "\\\\") + "'");
+                    _luaInterpreter.DoString("ProfileName = " + "'" + ConfigManager.ProfileName + "'");
                 }
                 return _luaInterpreter;
             }

--- a/Helios/HeliosProfile.cs
+++ b/Helios/HeliosProfile.cs
@@ -81,7 +81,7 @@ namespace GadrocsWorkshop.Helios
         public event EventHandler ProfileStarted;
         public event EventHandler ProfileTick;
         public event EventHandler ProfileStopped;
-        public event EventHandler ControlCenterChangeProfile;
+        public event EventHandler ProfileTransferControl;
 
         // this event indicates that some interface received an indication that a profile that 
         // matches the specified hint should be loaded
@@ -262,9 +262,9 @@ namespace GadrocsWorkshop.Helios
             ControlCenterShown?.Invoke(this, EventArgs.Empty);
         }
 
-        public void ChangeProfileControlCenter(HeliosActionEventArgs e)
+        public void TransferControlToProfile(HeliosActionEventArgs e)
         {
-            ControlCenterChangeProfile?.Invoke(this, e);
+            ProfileTransferControl?.Invoke(this, e);
         }
         public void HideControlCenter()
         {

--- a/Helios/HeliosProfile.cs
+++ b/Helios/HeliosProfile.cs
@@ -81,6 +81,7 @@ namespace GadrocsWorkshop.Helios
         public event EventHandler ProfileStarted;
         public event EventHandler ProfileTick;
         public event EventHandler ProfileStopped;
+        public event EventHandler ControlCenterChangeProfile;
 
         // this event indicates that some interface received an indication that a profile that 
         // matches the specified hint should be loaded
@@ -261,6 +262,10 @@ namespace GadrocsWorkshop.Helios
             ControlCenterShown?.Invoke(this, EventArgs.Empty);
         }
 
+        public void ChangeProfileControlCenter(HeliosActionEventArgs e)
+        {
+            ControlCenterChangeProfile?.Invoke(this, e);
+        }
         public void HideControlCenter()
         {
             ControlCenterHidden?.Invoke(this, EventArgs.Empty);

--- a/Helios/Interfaces/HeliosInformation/HeliosInformationInterface.cs
+++ b/Helios/Interfaces/HeliosInformation/HeliosInformationInterface.cs
@@ -25,18 +25,24 @@ namespace GadrocsWorkshop.Helios.Interfaces.HeliosInformation
     public class HeliosInformationInterface : HeliosInterface, IExtendedDescription
     {
         private HeliosValue _heliosVersion;
-        
+        private HeliosValue _heliosProfileName;
+
         public HeliosInformationInterface()
             : base("Helios Information")
         {
             _heliosVersion = new HeliosValue(this, BindingValue.Empty, "Helios Version", "Helios Version", "The Helios Version number.", "Example: 1.6.1000.0000", BindingValueUnits.Text);
             Values.Add(_heliosVersion);
             Triggers.Add(_heliosVersion);
+
+            _heliosProfileName = new HeliosValue(this, BindingValue.Empty, "", "Active Profile Name", "Name of the Active Profile.", "Text value without filetype suffix", BindingValueUnits.Text);
+            Values.Add(_heliosProfileName);
+            Triggers.Add(_heliosProfileName);
         }
 
-		private void Profile_ProfileTick(object sender, EventArgs e)
+        private void Profile_ProfileTick(object sender, EventArgs e)
         {
             _heliosVersion.SetValue(new BindingValue(ConfigManager.HeliosVersion), false);
+            _heliosProfileName.SetValue(new BindingValue(ConfigManager.ProfileName), false);
         }
 
         #region Overrides of HeliosInterface

--- a/Helios/Interfaces/HeliosInformation/HeliosInformationInterfaceEditor.xaml
+++ b/Helios/Interfaces/HeliosInformation/HeliosInformationInterfaceEditor.xaml
@@ -18,13 +18,15 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
                     <TextBlock Grid.Row="0" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="Helios Information Interface provides details about the version you are running."/>
                     <TextBlock Grid.Row="1" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="" Name="HeliosVersion"/>
                     <TextBlock Grid.Row="2" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="" Name="HeliosPath"/>
-                    <TextBlock Grid.Row="3" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="" Name="BMSFalconPath"/>
-                </Grid>
+					<TextBlock Grid.Row="3" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="" Name="BMSFalconPath"/>
+					<TextBlock Grid.Row="3" Grid.Column="1" Style="{StaticResource InterfaceEditorStatus}" Text="" Name="ProfileName"/>
+				</Grid>
             </Grid>
         </GroupBox>
         <GroupBox Style="{StaticResource BasicGroup}" Header="Configuration">

--- a/Helios/Interfaces/HeliosInformation/HeliosInformationInterfaceEditor.xaml.cs
+++ b/Helios/Interfaces/HeliosInformation/HeliosInformationInterfaceEditor.xaml.cs
@@ -35,6 +35,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.HeliosInformation
             HeliosVersion.Text = "Helios Version: " + ConfigManager.HeliosVersion;
             HeliosPath.Text = "Helios Path: " + ConfigManager.DocumentPath;
             BMSFalconPath.Text = "BMS Falcon Path: " + ConfigManager.BMSFalconPath;
+            ProfileName.Text = "Active Profile Name: the name of the profile being run by Control Center";
 
             BMSFalconPath.Visibility = ConfigManager.BMSFalconPath.Length > 0 ? Visibility.Visible : Visibility.Collapsed;
         }

--- a/Helios/Interfaces/Profile/ProfileInterface.cs
+++ b/Helios/Interfaces/Profile/ProfileInterface.cs
@@ -69,10 +69,9 @@ namespace GadrocsWorkshop.Helios.Interfaces.Profile
             hideControlCenter.Execute += new HeliosActionHandler(HideAction_Execute);
             Actions.Add(hideControlCenter);
 
-            HeliosAction changeControlCenter = new HeliosAction(this, "", "", "change control center profile", "Changes the control center profile.", "Profile name",
-BindingValueUnits.Text);
-            changeControlCenter.Execute += new HeliosActionHandler(ChangeProfileAction_Execute);
-            Actions.Add(changeControlCenter);
+            HeliosAction profileTransferControl = new HeliosAction(this, "", "", "transfer control", "Stops the current profile and starts a new profile.", "Profile name", BindingValueUnits.Text);
+            profileTransferControl.Execute += new HeliosActionHandler(ProfileTransferControlAction_Execute);
+            Actions.Add(profileTransferControl);
 
             HeliosAction launchApplication = new HeliosAction(this, "", "", "launch application", "This functionality has moved to Process Control interface", "This action will be ignored.", BindingValueUnits.Text);
             launchApplication.Execute += LaunchApplication_Execute;
@@ -240,9 +239,9 @@ BindingValueUnits.Text);
             Profile?.Reset();
         }
 
-        private void ChangeProfileAction_Execute(object action, HeliosActionEventArgs e)
+        private void ProfileTransferControlAction_Execute(object action, HeliosActionEventArgs e)
         {
-            Profile?.ChangeProfileControlCenter(e);
+            Profile?.TransferControlToProfile(e);
         }
 
         public void Subscribe(IStatusReportObserver observer)

--- a/Helios/Interfaces/Profile/ProfileInterface.cs
+++ b/Helios/Interfaces/Profile/ProfileInterface.cs
@@ -69,6 +69,11 @@ namespace GadrocsWorkshop.Helios.Interfaces.Profile
             hideControlCenter.Execute += new HeliosActionHandler(HideAction_Execute);
             Actions.Add(hideControlCenter);
 
+            HeliosAction changeControlCenter = new HeliosAction(this, "", "", "change control center profile", "Changes the control center profile.", "Profile name",
+BindingValueUnits.Text);
+            changeControlCenter.Execute += new HeliosActionHandler(ChangeProfileAction_Execute);
+            Actions.Add(changeControlCenter);
+
             HeliosAction launchApplication = new HeliosAction(this, "", "", "launch application", "This functionality has moved to Process Control interface", "This action will be ignored.", BindingValueUnits.Text);
             launchApplication.Execute += LaunchApplication_Execute;
             Actions.Add(launchApplication);
@@ -233,6 +238,11 @@ namespace GadrocsWorkshop.Helios.Interfaces.Profile
         private void ResetAction_Execute(object action, HeliosActionEventArgs e)
         {
             Profile?.Reset();
+        }
+
+        private void ChangeProfileAction_Execute(object action, HeliosActionEventArgs e)
+        {
+            Profile?.ChangeProfileControlCenter(e);
         }
 
         public void Subscribe(IStatusReportObserver observer)

--- a/Profile Editor/BindingsPanel.xaml
+++ b/Profile Editor/BindingsPanel.xaml
@@ -245,7 +245,7 @@
 
                         <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
                             <TextBlock FontSize="10" TextWrapping="Wrap" Margin="4,4,4,0" Text="{Binding SelectedBinding.ErrorMessage}" Foreground="Red" Style="{StaticResource ErrorMessageStyle}" />
-                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4">
+                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4"  xml:space="preserve">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource Documentation}">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -260,13 +260,17 @@
                                         </Style.Triggers>
                                     </Style>
                                 </TextBlock.Style>
-                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger. A global variable named "HeliosPath" will be populated with the Helios Path value.</TextBlock.Text>
+                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger.
+Other Global Variables:
+"HeliosPath" will be populated with the Helios Path value.
+"ProfileName" will be populated with the name of the active profile.
+                                </TextBlock.Text>
                             </TextBlock>
                         </StackPanel>
 
                         <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
                             <TextBlock FontSize="10" TextWrapping="Wrap" Margin="4,4,4,0" Text="{Binding SelectedBinding.ErrorMessage}" Foreground="Red" Style="{StaticResource ErrorMessageStyle}" />
-                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4">
+                            <TextBlock FontSize="9" TextWrapping="Wrap" Margin="4,1,4,4" xml:space="preserve">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource Documentation}">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -281,7 +285,11 @@
                                         </Style.Triggers>
                                     </Style>
                                 </TextBlock.Style>
-                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger. Global variables named "HeliosPath" and "BMSFalconPath" will be populated with the Helios and BMS Falcon Path values respectively.</TextBlock.Text>
+                                <TextBlock.Text>Return value from the script will be passed to the action. A global variable named "TriggerValue" will be populated with the value passed in from the trigger.
+Other Global Variables:
+"HeliosPath" will be populated with the Helios Path value
+"BMSFalconPath" will be populated with the BMS Falcon Path value
+"ProfileName" will be populated with the name of the active profile.</TextBlock.Text>
                             </TextBlock>
                         </StackPanel>
                     </Grid>


### PR DESCRIPTION
This is an implementation of the code supplied in #760 by @finbarlay
While largely as supplied, this implementation restricts the new profile location and carries the name "Transfer Control".  Also in this PR is a new LuaScript Global Variable for the profile name, and there is now an additional profile name value in the HeliosInformation interface.  As supplied, the Transfer Control preserves the image cache which hopefully will limit the time taken to transfer control to a new profile. 