### PR TITLE
Addition of AH-64D Glass Opacity to MFDs, TEDAC, and EUFDs

### DIFF
--- a/Aircraft AH-64D Plugin/Gauges/EUFD/EUFD.cs
+++ b/Aircraft AH-64D Plugin/Gauges/EUFD/EUFD.cs
@@ -22,6 +22,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
     using System.Xml;
     using System.Windows;
     using System.Windows.Media;
+    using System.Globalization;
 
     [HeliosControl("Helios.AH64D.EUFD", "Enhanced Up Front Display", "AH-64D", typeof(BackgroundImageRenderer), HeliosControlFlags.NotShownInUI)]
     public class EUFD : CompositeVisualWithBackgroundImage
@@ -35,6 +36,8 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
         private bool _includeViewport = true;
         private string _vpName = "";
         private const string Panel_Image = "{AH-64D}/Images/EUFD/EUFD.png";
+        public const double GLASS_REFLECTION_OPACITY_DEFAULT = 0.30d;
+        private double _glassReflectionOpacity = GLASS_REFLECTION_OPACITY_DEFAULT;
 
         public EUFD(string interfaceDevice)
             : base(interfaceDevice, new Size(1004, 348))
@@ -55,7 +58,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
             }
             if (_includeViewport) AddViewport(_vpName);
             _frameGlassPanel = AddPanel("EUFD Glass", new Point(Left + (173), Top + (25)), new Size(600d, 300d), "{AH-64D}/Images/MFD/MFD_glass.png", _interfaceDevice);
-            _frameGlassPanel.Opacity = 0.3d;
+            _frameGlassPanel.Opacity = _glassReflectionOpacity;
             _frameGlassPanel.DrawBorder = false;
             _frameGlassPanel.FillBackground=false;
  
@@ -324,6 +327,25 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
         {
             _frameBezelPanel.BackgroundImage = BackgroundImageIsCustomized ? null : Panel_Image;
         }
+        public double GlassReflectionOpacity
+        {
+            get
+            {
+                return _glassReflectionOpacity;
+            }
+            set
+            {
+                double oldValue = _glassReflectionOpacity;
+                if (value != oldValue)
+                {
+                    _glassReflectionOpacity = value;
+                    OnPropertyChanged("GlassReflectionOpacity", oldValue, value, true);
+                    _frameGlassPanel.IsHidden = _glassReflectionOpacity == 0d ? true : false;
+                    _frameGlassPanel.Opacity = _glassReflectionOpacity;
+
+                }
+            }
+        }
 
         public override bool HitTest(Point location)
         {
@@ -356,6 +378,11 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
             {
                 writer.WriteElementString("EmbeddedViewportName", "");
             }
+            if (_glassReflectionOpacity > 0d)
+            {
+                writer.WriteElementString("GlassReflectionOpacity", GlassReflectionOpacity.ToString(CultureInfo.InvariantCulture));
+            }
+
         }
 
         public override void ReadXml(XmlReader reader)
@@ -372,6 +399,8 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.EUFD
                 _includeViewport = false;
                 RemoveViewport("");
             }
+            GlassReflectionOpacity = reader.Name.Equals("GlassReflectionOpacity") ? double.Parse(reader.ReadElementString("GlassReflectionOpacity"), CultureInfo.InvariantCulture) : 0d;
+
         }
     }
 }

--- a/Aircraft AH-64D Plugin/Gauges/TEDAC/TEDAC.cs
+++ b/Aircraft AH-64D Plugin/Gauges/TEDAC/TEDAC.cs
@@ -22,6 +22,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
     using System.Xml;
     using System.Windows;
     using System.Windows.Media;
+    using System.Globalization;
 
 
     [HeliosControl("Helios.AH64D.TEDAC", "TADS Electronic Display and Control", "AH-64D", typeof(BackgroundImageRenderer),HeliosControlFlags.NotShownInUI)]
@@ -36,6 +37,8 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
         private bool _includeViewport = true;
         private string _vpName = "";
         private const string Panel_Image = "{AH-64D}/Images/TEDAC/TEDAC_frame.png";
+        public const double GLASS_REFLECTION_OPACITY_DEFAULT = 0.30d;
+        private double _glassReflectionOpacity = GLASS_REFLECTION_OPACITY_DEFAULT;
 
         public TEDAC()
             : base("TEDAC", new Size(1089, 1080))
@@ -45,7 +48,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
             _vpName = "AH_64D_TEDAC";
             if (_includeViewport) AddViewport(_vpName);
             _frameGlassPanel = AddPanel("TEDAC Glass", new Point(142, 150), new Size(800d, 800d), "{AH-64D}/Images/MFD/MFD_glass.png", _interfaceDevice);
-            _frameGlassPanel.Opacity = 0.3d;
+            _frameGlassPanel.Opacity = _glassReflectionOpacity;
             _frameGlassPanel.DrawBorder = false;
             _frameGlassPanel.FillBackground=false;
  
@@ -374,7 +377,25 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
         {
             _frameBezelPanel.BackgroundImage = BackgroundImageIsCustomized ? null : Panel_Image;
         }
+        public double GlassReflectionOpacity
+        {
+            get
+            {
+                return _glassReflectionOpacity;
+            }
+            set
+            {
+                double oldValue = _glassReflectionOpacity;
+                if (value != oldValue)
+                {
+                    _glassReflectionOpacity = value;
+                    OnPropertyChanged("GlassReflectionOpacity", oldValue, value, true);
+                    _frameGlassPanel.IsHidden = _glassReflectionOpacity == 0d ? true : false;
+                    _frameGlassPanel.Opacity = _glassReflectionOpacity;
 
+                }
+            }
+        }
         public override bool HitTest(Point location)
         {
             if (_scaledScreenRect.Contains(location))
@@ -407,6 +428,10 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
             {
                 writer.WriteElementString("EmbeddedViewportName", "");
             }
+            if (_glassReflectionOpacity > 0d)
+            {
+                writer.WriteElementString("GlassReflectionOpacity", GlassReflectionOpacity.ToString(CultureInfo.InvariantCulture));
+            }
 
         }
         public override void ReadXml(XmlReader reader)
@@ -430,6 +455,7 @@ namespace GadrocsWorkshop.Helios.Gauges.AH64D.TEDAC
                     }
                 }
             }
+            GlassReflectionOpacity = reader.Name.Equals("GlassReflectionOpacity") ? double.Parse(reader.ReadElementString("GlassReflectionOpacity"), CultureInfo.InvariantCulture) : 0d;
         }
     }
 }

--- a/Helios/Controls/GlassOpacityAppearanceEditor.xaml.cs
+++ b/Helios/Controls/GlassOpacityAppearanceEditor.xaml.cs
@@ -45,7 +45,13 @@
     [HeliosPropertyEditor("Helios.M2000C.ADI.Backup", "Appearance")]
     [HeliosPropertyEditor("Helios.M2000C.Accelerometer", "Appearance")]
     [HeliosPropertyEditor("Helios.M2000C.Instruments.VVI", "Appearance")]
-    
+    [HeliosPropertyEditor("Helios.AH64D.MFD.CPGLEFT", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.MFD.CPGRIGHT", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.MFD.PLTLEFT", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.MFD.PLTRIGHT", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.TEDAC", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.EUFD.CPG", "Appearance")]
+    [HeliosPropertyEditor("Helios.AH64D.EUFD.PILOT", "Appearance")]
 
     public partial class GlassOpacityAppearanceEditor : HeliosPropertyEditor
     {


### PR DESCRIPTION
When originally written, the ability to alter the opacity of the glass was not available, and therefore not included for the AH-64D built in controls / gauges.  This is a retro-fit enhancement of this behaviour to Profile Editor to allow the opacity changes for the AH-64D MFDs, TEDAC, and EUFDs.