### PR TITLE
Fixes for issue 791 Some KA-50 gauges showing too small values

### DIFF
--- a/Aircraft Ka-50 Plugin/Gauges/BaroAltimeter/BaroAltimeter.cs
+++ b/Aircraft Ka-50 Plugin/Gauges/BaroAltimeter/BaroAltimeter.cs
@@ -42,6 +42,28 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BaroAltimeter
             _qfeCalibration = new CalibrationPointCollectionDouble(600d, 0d, 800d, 300d);
             _needleCalibration = new CalibrationPointCollectionDouble(0d, 0d, 10d, 360d);
 
+
+            _qfeCalibration.Add( new CalibrationPointDouble( 612d, 15d ) );   // 610   
+            _qfeCalibration.Add( new CalibrationPointDouble( 624d, 30d ) );   // 620   
+            _qfeCalibration.Add( new CalibrationPointDouble( 635d, 45d ) );  // 630
+            _qfeCalibration.Add( new CalibrationPointDouble( 648d, 60d ) );  // 640
+            _qfeCalibration.Add( new CalibrationPointDouble( 658d, 75d ) );  // 650
+            _qfeCalibration.Add( new CalibrationPointDouble( 668d, 90d ) );  // 660
+            _qfeCalibration.Add( new CalibrationPointDouble( 680d, 104.9d ) );  // 670
+            _qfeCalibration.Add( new CalibrationPointDouble( 688d, 119.8d ) );  // 680
+            _qfeCalibration.Add( new CalibrationPointDouble( 698d, 134.5d ) );  // 690
+            _qfeCalibration.Add( new CalibrationPointDouble( 708d, 149.5d ) );  // 700
+            _qfeCalibration.Add( new CalibrationPointDouble( 718d, 164.3d ) );  // 710
+            _qfeCalibration.Add( new CalibrationPointDouble( 728d, 179.3d ) );  // 720
+            _qfeCalibration.Add( new CalibrationPointDouble( 738d, 194d ) );  // 730
+            _qfeCalibration.Add( new CalibrationPointDouble( 746d, 209d ) );  // 740
+            _qfeCalibration.Add( new CalibrationPointDouble( 755d, 224d ) );  // 750
+            _qfeCalibration.Add( new CalibrationPointDouble( 765d, 239.2d ) );  // 760
+            _qfeCalibration.Add( new CalibrationPointDouble( 774d, 254.2d ) );  // 770
+            _qfeCalibration.Add( new CalibrationPointDouble( 782d, 269.3d ) );  // 780
+            _qfeCalibration.Add( new CalibrationPointDouble( 792d, 284.8d ) );  // 790
+        
+
             _qfeCard = new GaugeNeedle("{Ka-50}/Gauges/BaroAltimeter/baro_alt_qfe_card.xaml", center, new Size(264, 264), new Point(132, 132), 300d);
             Components.Add(_qfeCard);
 

--- a/Aircraft Ka-50 Plugin/Gauges/BladeAngle/BladeAngle.cs
+++ b/Aircraft Ka-50 Plugin/Gauges/BladeAngle/BladeAngle.cs
@@ -26,6 +26,8 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BladeAngle
         private HeliosValue _angle;
         private CalibrationPointCollectionDouble _callibration;
 
+        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger( );
+
         public BladeAngle()
             : base("Blade Angle", new Size(340, 340))
         {
@@ -36,7 +38,16 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BladeAngle
             _needle = new GaugeNeedle("{Ka-50}/Gauges/BladeAngle/blade_angle_needle.xaml", center, new Size(40, 159), new Point(20, 139), -105d);
             Components.Add(_needle);
 
-            _callibration = new CalibrationPointCollectionDouble(1d, 0d, 15d, 210d);
+            _callibration = new CalibrationPointCollectionDouble(0d, 0d, 15d, 210d);
+            _callibration.Add( new CalibrationPointDouble( 0.68d, 7d ) ); // 1.5 degree
+            _callibration.Add( new CalibrationPointDouble( 1.35d, 15d ) ); // 2 degrees 
+            _callibration.Add( new CalibrationPointDouble( 2.51d, 30d ) ); // 3 degrees 
+            _callibration.Add( new CalibrationPointDouble( 4.66d, 60d ) ); // 5 degrees 
+            _callibration.Add( new CalibrationPointDouble( 6.61d, 89d ) ); // 7 degrees 
+            _callibration.Add( new CalibrationPointDouble( 8.39d, 119d ) ); // 9 degrees 
+            _callibration.Add( new CalibrationPointDouble( 10.27d, 149d ) );   // 11 degrees 
+            _callibration.Add( new CalibrationPointDouble( 12.45d, 178d ) );  // 13 degrees
+            _callibration.Add( new CalibrationPointDouble( 14.95d, 210d ) );  // 15 degrees
 
             _angle = new HeliosValue(this, BindingValue.Empty, "", "Blade Angle", "Angle of the blades", "", BindingValueUnits.Degrees);
             _angle.Execute += Angle_Execute;
@@ -47,6 +58,8 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BladeAngle
 
         private void Angle_Execute(object action, HeliosActionEventArgs e)
         {
+        //    Logger.Info( "Blade Angle value received: " + e.Value.DoubleValue );
+
             _angle.SetValue(e.Value, e.BypassCascadingTriggers);
             _needle.Rotation = _callibration.Interpolate(e.Value.DoubleValue);
         }

--- a/Aircraft Ka-50 Plugin/Gauges/BladeAngle/BladeAngle.cs
+++ b/Aircraft Ka-50 Plugin/Gauges/BladeAngle/BladeAngle.cs
@@ -26,8 +26,6 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BladeAngle
         private HeliosValue _angle;
         private CalibrationPointCollectionDouble _callibration;
 
-        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger( );
-
         public BladeAngle()
             : base("Blade Angle", new Size(340, 340))
         {
@@ -58,8 +56,6 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.BladeAngle
 
         private void Angle_Execute(object action, HeliosActionEventArgs e)
         {
-        //    Logger.Info( "Blade Angle value received: " + e.Value.DoubleValue );
-
             _angle.SetValue(e.Value, e.BypassCascadingTriggers);
             _needle.Rotation = _callibration.Interpolate(e.Value.DoubleValue);
         }

--- a/Aircraft Ka-50 Plugin/Gauges/RadarAltimeter/RadarAltimeter.cs
+++ b/Aircraft Ka-50 Plugin/Gauges/RadarAltimeter/RadarAltimeter.cs
@@ -38,7 +38,7 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.RadarAltimeter
         {
             Point center = new Point(170, 170);
 
-            _needleCalibration = new CalibrationPointCollectionDouble(0d, 0d, 300d, 330d);
+            _needleCalibration = new CalibrationPointCollectionDouble(0d, 0d, 350d, 330d);
             _needleCalibration.Add(new CalibrationPointDouble(20d, 66d));
             _needleCalibration.Add(new CalibrationPointDouble(30d, 115d));
             _needleCalibration.Add(new CalibrationPointDouble(50d, 165d));

--- a/Aircraft Ka-50 Plugin/Gauges/RotorRPM/RotorRPM.cs
+++ b/Aircraft Ka-50 Plugin/Gauges/RotorRPM/RotorRPM.cs
@@ -32,6 +32,10 @@ namespace GadrocsWorkshop.Helios.Gauges.KA_50.RotorRPM
             Point center = new Point(170, 170);
 
             _needleCalibration = new CalibrationPointCollectionDouble(0d, 0d, 110d, 346.5d);
+            _needleCalibration.Add( new CalibrationPointDouble( 33d, 110d ) );  // in gauge: 35%
+            _needleCalibration.Add( new CalibrationPointDouble( 55d, 182d ) );  // in gauge: 58%
+            _needleCalibration.Add( new CalibrationPointDouble( 88d, 287d ) );  // in gauge: 91%
+            _needleCalibration.Add( new CalibrationPointDouble( 99d, 312d ) );  // in gauge: 101%
 
             Components.Add(new GaugeImage("{Ka-50}/Gauges/RotorRPM/rotor_rpm_faceplate.xaml", new Rect(0, 0, 340, 340)));
 

--- a/Aircraft Ka-50 Plugin/Interfaces/BlackSharkInterface.cs
+++ b/Aircraft Ka-50 Plugin/Interfaces/BlackSharkInterface.cs
@@ -208,7 +208,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.BlackShark
             // Laser RangeFinder
             AddFunction(GuardedSwitch.CreateToggleSwitch(this, LASERRANGER, BUTTON_3, "56", BUTTON_2, "57", "1", "0", "0", "Norm", "1", "Stand By", "Laser Ranger", "Mode Switch", "%1d"));
             AddFunction(new PushButton(this, LASERRANGER, BUTTON_4, "55", "Laser Ranger", "Designator Reset"));
-            
+
             // Blade Angle
             AddFunction(new ScaledNetworkValue(this, "53", 15d, "Rotor", "Pitch", "Current pitch of the rotor blades", "(0-15)", BindingValueUnits.Degrees));
 
@@ -217,13 +217,28 @@ namespace GadrocsWorkshop.Helios.Interfaces.DCS.BlackShark
 
             // Radar Altimeter
             CalibrationPointCollectionDouble radarAltScale = new CalibrationPointCollectionDouble(0.0d, 0.0d, 1.0d, 350d);
-            radarAltScale.Add(new CalibrationPointDouble(0.1838d, 20d));
-            radarAltScale.Add(new CalibrationPointDouble(0.4631d, 50d));
-            radarAltScale.Add(new CalibrationPointDouble(0.7541d, 150d));
-            radarAltScale.Add(new CalibrationPointDouble(0.8330d, 200d));
-            radarAltScale.Add(new CalibrationPointDouble(0.9329d, 300d));
-            AddFunction(new ScaledNetworkValue(this, "94", radarAltScale, "Radar Altimeter", "Altitude", "", "0-300", BindingValueUnits.Meters));
-            AddFunction(new ScaledNetworkValue(this, "93", radarAltScale, "Radar Altimeter", "Dangerouse Altitude Index", "", "0-300", BindingValueUnits.Meters));
+            //radarAltScale.Add(new CalibrationPointDouble(0.1838d, 20d));
+            //radarAltScale.Add(new CalibrationPointDouble(0.4631d, 50d));
+            //radarAltScale.Add(new CalibrationPointDouble(0.7541d, 150d));
+            //radarAltScale.Add(new CalibrationPointDouble(0.8330d, 200d));
+            //radarAltScale.Add(new CalibrationPointDouble(0.9329d, 300d));
+            radarAltScale.Add( new CalibrationPointDouble( 0.0d, 0d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.095d, 10d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.181d, 20d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.264d, 30d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.345d, 40d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.427d, 50d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.510d, 80d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.570d, 100d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.659d, 130d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.716d, 150d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.802d, 200d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.875d, 250d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 0.9329d, 300d ) );
+            radarAltScale.Add( new CalibrationPointDouble( 1.0d, 350d ) );
+
+            AddFunction(new ScaledNetworkValue(this, "94", radarAltScale, "Radar Altimeter", "Altitude", "", "0-350", BindingValueUnits.Meters));
+            AddFunction(new ScaledNetworkValue(this, "93", radarAltScale, "Radar Altimeter", "Dangerouse Altitude Index", "", "0-350", BindingValueUnits.Meters));
             AddFunction(new FlagValue(this, "95", "Radar Altimeter", "Warning Flag", "Flag displayed when radar altimeter is not functioning."));
             AddFunction(new RotaryEncoder(this, RADAR_ALTIMETER, BUTTON_1, "91", 0.1d, "Radar Altimeter", "Dangerous RALT set rotary"));
             AddFunction(new FlagValue(this, "92", "Radar Altimeter", "Dangerous altitude indicator", ""));

--- a/Aircraft Ka-50 Plugin/Interfaces/ExportFunctionsKa-50_3.lua
+++ b/Aircraft Ka-50 Plugin/Interfaces/ExportFunctionsKa-50_3.lua
@@ -1,6 +1,6 @@
 -- Lookup tables for weapons store type display
-driver.gStationTypes = {["9A4172"] = "NC", ["S-8KOM"] = "HP", ["S-13"] = "HP", ["UPK-23-250"] = "NN", ["AO-2.5RT"] = "A6", ["PTAB-2.5KO"] = "A6",
-				 ["FAB-250"] = "A6", ["FAB-500"] = "A6" }
+driver.gStationTypes = {["9M127-1 Vikhr-M"] = "NC", ["Kh-25ML (AS-10 Karen)"] = "NC", ["S-8KOM HEAT/Frag"] = "HP", ["S-8TsM SM Orange"] = "HP", ["S-8OFP2 MPP"] = "HP", ["S-8OM IL"] = "HP", ["S-13"] = "HP", ["UPK-23-250"] = "NN", ["BKF - 12 x AO-2.5RT"] = "A6", ["BKF - 12 x PTAB-2.5KO"] = "A6",
+				 ["FAB-250"] = "A6", ["FAB-250-M62 GP"] ="A6", ["FAB-500"] = "A6" }  
 
 -- State data
 driver.gTrigger = 0


### PR DESCRIPTION
Fixes for KA-50 BS3 gauges:
- Rotor RPM
- Rotor Blade Angle
- QFE on barometric altimeter
- Radar Altimeter

Fix for store (weapon) type display. It has changed in DCS since original version of interface was done.